### PR TITLE
Tao remove asserts and refactor

### DIFF
--- a/src/meili/routing.cc
+++ b/src/meili/routing.cc
@@ -274,7 +274,6 @@ void set_destinations(baldr::GraphReader& reader,
 
   for (uint16_t dest = 0; dest < destinations.size(); dest++) {
     for (const auto& edge : destinations[dest].edges()) {
-      assert(edge.id.Is_Valid());
       if (!edge.id.Is_Valid()) continue;
 
       if (edge.dist == 0.f) {
@@ -448,14 +447,14 @@ find_shortest_path(baldr::GraphReader& reader,
 
       const auto inbound_heading = (pred_edgelabel && turn_cost_table)?
                                    get_inbound_edgelabel_heading(reader, tile, *pred_edgelabel, *nodeinfo) : 0;
-      assert(0 <= inbound_heading && inbound_heading < 360);
+      // TODO: test it assert(0 <= inbound_heading && inbound_heading < 360);
 
       // Expand current node
       baldr::GraphId other_edgeid(nodeid.tileid(), nodeid.level(), nodeinfo->edge_index());
       auto other_edge = tile->directededge(nodeinfo->edge_index());
       for (size_t i = 0; i < nodeinfo->edge_count(); i++, other_edge++, other_edgeid++) {
         if (other_edge->trans_up() || other_edge->trans_down()) continue;
-        assert(nodeid.level() == other_edge->endnode().level());
+        // TODO: @kevinkreiser is it true if trans is disabled? assert(nodeid.level() == other_edge->endnode().level());
 
         if (!IsEdgeAllowed(other_edge, other_edgeid, costing, pred_edgelabel, edgefilter, tile)) continue;
 
@@ -463,9 +462,9 @@ find_shortest_path(baldr::GraphReader& reader,
         float turn_cost = 0.f;
         if (pred_edgelabel && turn_cost_table) {
           const auto other_heading = get_outbound_edge_heading(tile, other_edge, *nodeinfo);
-          assert(0 <= other_heading && other_heading < 360);
+          // TODO: test it assert(0 <= other_heading && other_heading < 360);
           const auto turn_degree = helpers::get_turn_degree180(inbound_heading, other_heading);
-          assert(0 <= turn_degree && turn_degree <= 180);
+          // TODO: test it assert(0 <= turn_degree && turn_degree <= 180);
           turn_cost = label_turn_cost + turn_cost_table[turn_degree];
         }
 

--- a/src/meili/routing.cc
+++ b/src/meili/routing.cc
@@ -162,10 +162,11 @@ LabelSet::pop()
       }
       if (status.permanent) {
         // For example, if the queue has popped up an index 2, and
-        // marked the label at this index as permanent, then some time
-        // later the queue pops up another index 2 (duplicated), this
-        // logic error will be thrown
-        throw std::logic_error("the indexes in the queue must be unique");
+        // marked the label at this index as permanent (optimal), then
+        // some time later the queue pops up another index 2
+        // (duplicated), this logic error will be thrown
+        throw std::logic_error("the principle of optimality is violated during routing,"
+                               " probably negative costs occurred");
       }
 
       status.permanent = true;
@@ -177,7 +178,8 @@ LabelSet::pop()
                                " is not synced up with the index poped from the queue" + std::to_string(idx));
       }
       if (status.permanent) {
-        throw std::logic_error("the indexes in the queue must be unique");
+        throw std::logic_error("the principle of optimality is violated during routing,"
+                               " probably negative costs occurred");
       }
 
       status.permanent = true;
@@ -408,7 +410,7 @@ find_shortest_path(baldr::GraphReader& reader,
 
   while (!labelset.empty()) {
     const auto label_idx = labelset.pop();
-    // NOTE this refernce is possible to be invalid when you add
+    // NOTE this reference is possible to be invalidated when you add
     // labels to the set later (which causes the label list
     // reallocated)
     const auto& label = labelset.label(label_idx);

--- a/src/meili/routing.cc
+++ b/src/meili/routing.cc
@@ -454,8 +454,7 @@ find_shortest_path(baldr::GraphReader& reader,
                      label_idx,
                      other_edge, travelmode, nullptr);
       }
-    } else {
-      assert(label.dest != kInvalidDestination);
+    } else { // assert(label.dest != kInvalidDestination)
       const auto dest = label.dest;
 
       // Path to a destination along an edge is found: remember it and

--- a/src/meili/routing.cc
+++ b/src/meili/routing.cc
@@ -25,7 +25,7 @@ bool
 LabelSet::put(const baldr::GraphId& nodeid, sif::TravelMode travelmode,
               std::shared_ptr<const sif::EdgeLabel> edgelabel)
 {
-  return put(nodeid, {},         // nodeid, (invalid) edgeid
+  return put(nodeid, {},         // nodeid, (dummy) edgeid
              0.f, 0.f,           // source, target
              0.f, 0.f, 0.f,      // cost, turn cost, sort cost
              kInvalidLabelIndex, // predecessor
@@ -86,7 +86,7 @@ bool
 LabelSet::put(uint16_t dest, sif::TravelMode travelmode,
               std::shared_ptr<const sif::EdgeLabel> edgelabel)
 {
-  return put(dest, {},           // dest, (invalid) edgeid
+  return put(dest, {},           // dest, (dummy) edgeid
              0.f, 0.f,           // source, target
              0.f, 0.f, 0.f,      // cost, turn cost, sort cost
              kInvalidLabelIndex, // predecessor
@@ -227,8 +227,12 @@ void set_origin(baldr::GraphReader& reader,
 {
   const baldr::GraphTile* tile = nullptr;
 
+  // Push dummy labels (invalid edgeid, zero cost, no predecessor) to
+  // the queue for the initial expansion later. These dummy labels
+  // will also serve as roots in search trees, and sentinels to
+  // indicate it reaches the begining of a route when constructing the
+  // route
   for (const auto& edge : destinations[origin_idx].edges()) {
-    assert(edge.id.Is_Valid());
     if (!edge.id.Is_Valid()) continue;
 
     if (edge.dist == 0.f) {
@@ -253,8 +257,7 @@ void set_origin(baldr::GraphReader& reader,
 #endif
 
       labelset.put(nodeid, travelmode, edgelabel);
-    } else {
-      assert(0.f < edge.dist && edge.dist < 1.f);
+    } else if (0.f < edge.dist && edge.dist < 1.f) {
       // Will decide whether to filter out this edge later
       labelset.put(origin_idx, travelmode, edgelabel);
     }

--- a/test/routing.cc
+++ b/test/routing.cc
@@ -19,7 +19,7 @@ using AdjacencyList = meili::BucketQueue<uint32_t, kInvalidKey>;
 void Add(AdjacencyList &adjlist, const std::vector<float>& costs)
 {
   uint32_t idx = 0;
-  for (auto cost : costs) {
+  for (const auto cost : costs) {
     adjlist.add(idx++, cost);
   }
 }
@@ -29,8 +29,8 @@ void TryRemove(AdjacencyList &adjlist, size_t num_to_remove, const std::vector<f
 {
   auto previous_cost = -std::numeric_limits<float>::infinity();
   for (size_t i = 0; i < num_to_remove && !adjlist.empty(); ++i) {
-    auto top = adjlist.pop();
-    auto cost = costs[top];
+    const auto top = adjlist.pop();
+    const auto cost = costs[top];
     if (!(previous_cost <= cost)) {
       throw std::runtime_error("TryAddRemove: expected order test failed");
     }
@@ -54,7 +54,7 @@ void TestAddRemove()
   // Test add randomly and remove
   costs.clear();
   for (size_t i = 0; i < 10000; i++) {
-    auto cost = std::floor(rand01() * 100000);
+    const auto cost = std::floor(rand01() * 100000);
     costs.push_back(cost);
   }
   AdjacencyList adjlist2(10000);
@@ -67,23 +67,34 @@ void TestAddRemove()
   AdjacencyList adjlist3(10);
   adjlist3.add(1, 100);
   if (!(adjlist3.empty() && adjlist3.cost(1) < 0.f)) {
-    throw std::runtime_error("TestAddRemove: 100 should not be added");
+    throw std::runtime_error("TestAddRemove: 100 should not be added since it is out of the queue range [0, 10)");
   }
   adjlist3.add(1, 10);
   if (!(adjlist3.empty() && adjlist3.cost(1) < 0.f)) {
-    throw std::runtime_error("TestAddRemove: 10 should not be added");
+    throw std::runtime_error("TestAddRemove: 10 should not be added since it is out of the queue range [0, 10)");
   }
   adjlist3.add(1, 9);
   if (!(!adjlist3.empty() && adjlist3.cost(1) == 9)) {
-    throw std::runtime_error("TestAddRemove: 9 should be added");
+    throw std::runtime_error("TestAddRemove: 9 should be added since it is within the queue range [0, 10)");
   }
   adjlist3.decrease(1, 3);
   if (!(!adjlist3.empty() && adjlist3.cost(1) == 3)) {
-    throw std::runtime_error("TestAddRemove: 3 should be decreased");
+    throw std::runtime_error("TestAddRemove: 3 should be decreased since it is less than the last cost 9");
   }
-  adjlist3.decrease(1, 5);
-  if (!(!adjlist3.empty() && adjlist3.cost(1) == 3)) {
-    throw std::runtime_error("TestAddRemove: 5 should not be decreased");
+
+  {
+    auto failed = false;
+    try {
+      adjlist3.decrease(1, 5);
+    } catch (const std::runtime_error& ex) {
+      failed = true;
+    }
+    if (!failed) {
+      throw std::runtime_error("TestAddRemove: it should fail to decrease cost to 5 since it is larger than last cost 3");
+    }
+    if (!(!adjlist3.empty() && adjlist3.cost(1) == 3)) {
+      throw std::runtime_error("TestAddRemove: the cost should still be 3 since it was failed to decrease to 5");
+    }
   }
 }
 
@@ -94,7 +105,7 @@ void TrySimulation(AdjacencyList& adjlist, size_t loop_count, size_t expansion_s
   // Track all label indexes in the adjlist
   std::unordered_set<uint32_t> track;
 
-  uint32_t idx = costs.size();
+  const uint32_t idx = costs.size();
   costs.push_back(10.f);
   bool inserted = adjlist.add(idx, 10.f);
   if (inserted) {
@@ -102,8 +113,8 @@ void TrySimulation(AdjacencyList& adjlist, size_t loop_count, size_t expansion_s
   }
 
   for (size_t i = 0; i < loop_count && !adjlist.empty(); i++) {
-    auto key = adjlist.pop();
-    auto min_cost = costs[key];
+    const auto key = adjlist.pop();
+    const auto min_cost = costs[key];
     // Must be the minimal one among the tracked labels
     for (auto k : track) {
       if (costs[k] < min_cost) {
@@ -113,22 +124,33 @@ void TrySimulation(AdjacencyList& adjlist, size_t loop_count, size_t expansion_s
     track.erase(key);
 
     for (size_t i = 0; i < expansion_size; i++) {
-      auto newcost = std::floor(min_cost + 1 + rand01() * max_increment_cost);
+      const auto newcost = std::floor(min_cost + 1 + rand01() * max_increment_cost);
       if (i % 2 == 0 && !track.empty()) {
         // Decrease cost
-        auto idx = *std::next(track.begin(), rand01() * track.size());
-        bool updated = adjlist.decrease(idx, newcost);
-        if (updated) {
-          if (newcost > costs[idx]) {
-            throw std::runtime_error("Simulation: wrong");
-          }
+        const auto idx = *std::next(track.begin(), rand01() * track.size());
+        if (newcost < costs[idx]) {
+          adjlist.decrease(idx, newcost);
           costs[idx] = newcost;
+          if (adjlist.cost(idx) != newcost) {
+            throw std::runtime_error("failed to decrease cost");
+          }
+        } else {
+          // Assert that it must fail to decrease since costs[idx] <= newcost
+          auto failed = false;
+          try {
+            adjlist.decrease(idx, newcost);
+          } catch (const std::runtime_error& ex) {
+            failed = true;
+          }
+          if (!failed) {
+            throw std::runtime_error("decreasing a non-less cost must fail");
+          }
         }
       } else {
         // Add new label
-        uint32_t idx = costs.size();
+        const uint32_t idx = costs.size();
         costs.push_back(newcost);
-        bool inserted = adjlist.add(idx, newcost);
+        const bool inserted = adjlist.add(idx, newcost);
         if (inserted) {
           track.insert(idx);
         }

--- a/valhalla/meili/priority_queue.h
+++ b/valhalla/meili/priority_queue.h
@@ -7,48 +7,20 @@
 #include <boost/heap/fibonacci_heap.hpp>
 
 
-template <typename T>
-class LabelInterface
-{
- public:
-  virtual ~LabelInterface() {
-  }
-  using id_type = T;
-  virtual T id() const = 0;
-  virtual double sortcost() const = 0;
-};
-
-template <typename T>
-bool operator>(const LabelInterface<T>& lhs, const LabelInterface<T>& rhs) {
-  return lhs.sortcost() > rhs.sortcost();
-}
-
-template <typename T>
-bool operator<(const LabelInterface<T>& lhs, const LabelInterface<T>& rhs) {
-  return lhs.sortcost() < rhs.sortcost();
-}
-
-template <typename T>
-bool operator==(const LabelInterface<T>& lhs, const LabelInterface<T>& rhs) {
-  return lhs.sortcost() == rhs.sortcost();
-}
-
-
 // Shortest-path-specific priority queue
 // (A friendly wrapper of boost::heap::fibonacci_heap)
-template <typename T>  // T must be type of LabelInterface
+template <typename T>
 class SPQueue
 {
  public:
   // Min heap
   using Heap = boost::heap::fibonacci_heap<T, boost::heap::compare<std::greater<T>>>;
 
-  ~SPQueue() {
-    clear();
-  }
+  ~SPQueue()
+  { clear(); }
 
   void push(const T& label) {
-    typename T::id_type id = label.id();
+    const auto id = label.id();
     auto handler_itr = handlers_.find(id);
     if (handler_itr == handlers_.end()) {
       handlers_[id] = heap_.push(label);
@@ -69,21 +41,23 @@ class SPQueue
     heap_.pop();
   }
 
-  const T& top() const {
-    return heap_.top();
-  }
+  const T& top() const
+  { return heap_.top(); }
 
-  bool empty() const {
+  bool empty() const
+  {
     assert(heap_.empty() == handlers_.empty());
     return heap_.empty();
   }
 
-  void clear() {
+  void clear()
+  {
     heap_.clear();
     handlers_.clear();
   }
 
-  typename Heap::size_type size() const {
+  typename Heap::size_type size() const
+  {
     assert(handlers_.size() == heap_.size());
     return heap_.size();
   }

--- a/valhalla/meili/priority_queue.h
+++ b/valhalla/meili/priority_queue.h
@@ -19,25 +19,21 @@ class SPQueue
   ~SPQueue()
   { clear(); }
 
-  void push(const T& label) {
-    const auto id = label.id();
-    auto handler_itr = handlers_.find(id);
-    if (handler_itr == handlers_.end()) {
-      handlers_[id] = heap_.push(label);
-    } else {
-      auto handler = handler_itr->second;
-      // Update it if it has lower cost
-      if (label < *handler) {
-        heap_.update(handler, label);
-      }
+  void push(const T& label)
+  {
+    const auto& id = label.id();
+    const auto it = handlers_.find(id);
+    if (it == handlers_.end()) {
+      handlers_.emplace(id, heap_.push(label));
+    } else if (label < *(it->second)) {
+      heap_.update(it->second, label);
     }
   }
 
-  void pop() {
-    auto top = heap_.top();
-    assert(handlers_.find(top.id()) != handlers_.end());
+  void pop()
+  {
+    const auto& top = heap_.top();
     handlers_.erase(top.id());
-    assert(handlers_.find(top.id()) == handlers_.end());
     heap_.pop();
   }
 
@@ -45,10 +41,7 @@ class SPQueue
   { return heap_.top(); }
 
   bool empty() const
-  {
-    assert(heap_.empty() == handlers_.empty());
-    return heap_.empty();
-  }
+  { return heap_.empty(); }
 
   void clear()
   {
@@ -57,13 +50,11 @@ class SPQueue
   }
 
   typename Heap::size_type size() const
-  {
-    assert(handlers_.size() == heap_.size());
-    return heap_.size();
-  }
+  { return heap_.size(); }
 
  protected:
   Heap heap_;
+
   std::unordered_map<typename T::id_type, typename Heap::handle_type> handlers_;
 };
 

--- a/valhalla/meili/routing.h
+++ b/valhalla/meili/routing.h
@@ -217,8 +217,7 @@ struct Label
         predecessor(the_predecessor),
         edgelabel(the_edgelabel)
   {
-    if ((nodeid.Is_Valid() && dest == kInvalidDestination)
-        || (!nodeid.Is_Valid() && dest != kInvalidDestination)) {
+    if (!((nodeid.Is_Valid() && dest == kInvalidDestination) || (!nodeid.Is_Valid() && dest != kInvalidDestination))) {
       throw std::invalid_argument("nodeid and dest must be mutually exclusive, i.e. either nodeid is valid or dest is valid");
     }
 

--- a/valhalla/meili/routing.h
+++ b/valhalla/meili/routing.h
@@ -165,6 +165,7 @@ class BucketQueue
 };
 
 
+// TODO simplify it by inheriting sif::EdgeLabel
 struct Label
 {
   Label() = delete;
@@ -195,8 +196,7 @@ struct Label
               the_source, the_target,
               the_cost, the_turn_cost, the_sortcost,
               the_predecessor,
-              the_edge, the_travelmode, the_edgelabel)
-  { assert(!nodeid.Is_Valid()); }
+              the_edge, the_travelmode, the_edgelabel) {}
 
   Label(const baldr::GraphId& the_nodeid,
         uint16_t the_dest,
@@ -213,19 +213,24 @@ struct Label
         predecessor(the_predecessor),
         edgelabel(the_edgelabel)
   {
+    if ((nodeid.Is_Valid() && dest == kInvalidDestination)
+        || (!nodeid.Is_Valid() && dest != kInvalidDestination)) {
+      throw std::invalid_argument("nodeid and dest must be mutually exclusive, i.e. either nodeid is valid or dest is valid");
+    }
+
     if (!(0.f <= source && source <= target && target <= 1.f)) {
-      throw std::runtime_error("invalid source ("
-                               + std::to_string(source)
-                               + ") or target ("
-                               + std::to_string(target) + ")");
+      throw std::invalid_argument("invalid source ("
+                                  + std::to_string(source)
+                                  + ") or target ("
+                                  + std::to_string(target) + ")");
     }
 
     if (cost < 0.f) {
-      throw std::runtime_error("invalid cost = " + std::to_string(cost));
+      throw std::invalid_argument("invalid cost = " + std::to_string(cost));
     }
 
     if (turn_cost < 0.f) {
-      throw std::runtime_error("invalid turn_cost = " + std::to_string(turn_cost));
+      throw std::invalid_argument("invalid turn_cost = " + std::to_string(turn_cost));
     }
 
     if (!edgelabel && the_edge) {
@@ -241,13 +246,14 @@ struct Label
     }
   }
 
-  // assert: nodeid.Is_Valid() XOR dest != kInvalidDestination
+  // Must be mutually exclusive, i.e. nodeid.Is_Valid() XOR dest != kInvalidDestination
   baldr::GraphId nodeid;
   uint16_t dest;
 
+  // Invalid graphid if dummy
   baldr::GraphId edgeid;
 
-  // assert: 0.f <= source <= target <= 1.f
+  // Assert: 0.f <= source <= target <= 1.f
   float source;
   float target;
 
@@ -258,8 +264,10 @@ struct Label
   // segment)
   float turn_cost;
 
+  // For ranking labels: sortcost = accumulated cost since origin + heuristic cost to the goal
   float sortcost;
 
+  // kInvalidLabelIndex if dummy
   uint32_t predecessor;
 
   // An EdgeLabel is needed here for passing to sif's filters later

--- a/valhalla/meili/viterbi_search.h
+++ b/valhalla/meili/viterbi_search.h
@@ -699,11 +699,11 @@ Time ViterbiSearch<T>::IterativeSearch(Time target, bool request_new_start)
 
     // Remove it from its column
     auto& column = unreached_states_[time];
-    const auto it = std::find_if(column.cbegin(), column.cend(),
+    const auto it = std::find_if(column.begin(), column.end(),
                                  [id] (const T* state) {
                                    return id == state->id();
                                  });
-    if (it == column.cend()) {
+    if (it == column.end()) {
       throw std::logic_error("the state must exist in the column");
     }
     column.erase(it);

--- a/valhalla/meili/viterbi_search.h
+++ b/valhalla/meili/viterbi_search.h
@@ -286,7 +286,6 @@ StateId NaiveViterbiSearch<T, Maximize>::SearchWinner(Time target)
       labels = InitLabels(column, false);
       UpdateLabels(labels, history_.back());
     }
-    assert(labels.size() == column.size());
 
     auto winner = FindWinner(labels);
     if (!winner && time > 0) {
@@ -327,27 +326,27 @@ void NaiveViterbiSearch<T, Maximize>::UpdateLabels(
     const std::vector<label_type>& prev_labels) const
 {
   for (const auto& prev_label : prev_labels) {
-    auto prev_state = prev_label.state;
+    const auto prev_state = prev_label.state;
 
-    auto prev_costsofar = prev_label.costsofar;
+    const auto prev_costsofar = prev_label.costsofar;
     if (kInvalidCost == prev_costsofar) {
       continue;
     }
 
     for (auto& label : labels) {
-      auto state = label.state;
+      const auto state = label.state;
 
-      auto emission_cost = EmissionCost(*state);
+      const auto emission_cost = EmissionCost(*state);
       if (kInvalidCost == emission_cost) {
         continue;
-      };
+      }
 
-      auto transition_cost = TransitionCost(*prev_state, *state);
+      const auto transition_cost = TransitionCost(*prev_state, *state);
       if (kInvalidCost == transition_cost) {
         continue;
       }
 
-      auto costsofar = CostSofar(prev_costsofar, transition_cost, emission_cost);
+      const auto costsofar = CostSofar(prev_costsofar, transition_cost, emission_cost);
       if (kInvalidCost == costsofar) {
         continue;
       }
@@ -370,7 +369,7 @@ NaiveViterbiSearch<T, Maximize>::InitLabels(
 {
   std::vector<label_type> labels;
   for (const auto state : column) {
-    auto initial_cost = use_emission_cost? EmissionCost(*state) : kInvalidCost;
+    const auto initial_cost = use_emission_cost? EmissionCost(*state) : kInvalidCost;
     labels.emplace_back(initial_cost, state, nullptr);
   }
   return labels;
@@ -405,15 +404,12 @@ template <typename T, bool Maximize>
 const typename NaiveViterbiSearch<T, Maximize>::label_type&
 NaiveViterbiSearch<T, Maximize>::label(const T& state) const
 {
-  auto time = state.time();
-
-  for (auto& label : history_[time]) {
+  for (const auto& label : history_[state.time()]) {
     if (label.state->id() == state.id()) {
       return label;
     }
   }
 
-  assert(false);
   throw std::runtime_error("impossible that label not found; if it happened, check SearchWinner");
 }
 

--- a/valhalla/meili/viterbi_search.h
+++ b/valhalla/meili/viterbi_search.h
@@ -51,22 +51,26 @@ struct StateLabel
 
 
 template <typename T>
-bool operator>(const StateLabel<T>& lhs, const StateLabel<T>& rhs)
+inline bool
+operator>(const StateLabel<T>& lhs, const StateLabel<T>& rhs)
 { return lhs.sortcost() > rhs.sortcost(); }
 
 
 template <typename T>
-bool operator<(const StateLabel<T>& lhs, const StateLabel<T>& rhs)
+inline bool
+operator<(const StateLabel<T>& lhs, const StateLabel<T>& rhs)
 { return lhs.sortcost() < rhs.sortcost(); }
 
 
 template <typename T>
-bool operator==(const StateLabel<T>& lhs, const StateLabel<T>& rhs)
+inline bool
+operator==(const StateLabel<T>& lhs, const StateLabel<T>& rhs)
 { return lhs.sortcost() == rhs.sortcost(); }
 
 
 template <typename T>
-bool operator!=(const StateLabel<T>& lhs, const StateLabel<T>& rhs)
+inline bool
+operator!=(const StateLabel<T>& lhs, const StateLabel<T>& rhs)
 { return !(lhs == rhs); }
 
 

--- a/valhalla/meili/viterbi_search.h
+++ b/valhalla/meili/viterbi_search.h
@@ -155,7 +155,7 @@ class IViterbiSearch
   // Get the state reference given its ID
   virtual const T& state(StateId id) const = 0;
 
-  virtual double AccumulatedCost(const StateId id) const = 0;
+  virtual double AccumulatedCost(StateId id) const = 0;
 
   virtual double AccumulatedCost(const T& state) const
   { return AccumulatedCost(state.id()); }
@@ -198,7 +198,7 @@ class NaiveViterbiSearch: public IViterbiSearch<T>
 
   const T& state(StateId id) const override;
 
-  double AccumulatedCost(const StateId id) const override;
+  double AccumulatedCost(StateId id) const override;
 
   double AccumulatedCost(const T& state) const override;
 
@@ -252,7 +252,7 @@ void NaiveViterbiSearch<T, Maximize>::Clear()
 
 template <typename T, bool Maximize>
 inline double
-NaiveViterbiSearch<T, Maximize>::AccumulatedCost(const StateId id) const
+NaiveViterbiSearch<T, Maximize>::AccumulatedCost(StateId id) const
 { return id != kInvalidStateId? AccumulatedCost(state(id)) : kInvalidCost; }
 
 
@@ -433,7 +433,7 @@ class ViterbiSearch: public IViterbiSearch<T>
 
   using IViterbiSearch<T>::AccumulatedCost;
 
-  virtual double AccumulatedCost(const StateId id) const override;
+  virtual double AccumulatedCost(StateId id) const override;
 
  protected:
   std::vector<const T*> state_;
@@ -514,7 +514,11 @@ template <typename T>
 inline StateId
 ViterbiSearch<T>::predecessor(StateId id) const
 {
-  const auto it = scanned_labels_.find(id);
+  // Let it throw out-of-bound here. This is by design to be
+  // consistent with NaiveViterbiSearch::predecessor
+  const auto& state = state_[id];
+
+  const auto it = scanned_labels_.find(state->id());
   if (it != scanned_labels_.end()) {
     return (it->second).predecessor? (it->second).predecessor->id() : kInvalidStateId;
   } else {
@@ -530,9 +534,13 @@ ViterbiSearch<T>::IsInvalidCost(double cost) const
 
 
 template <typename T>
-double ViterbiSearch<T>::AccumulatedCost(const StateId id) const
+double ViterbiSearch<T>::AccumulatedCost(StateId id) const
 {
-  const auto it = scanned_labels_.find(id);
+  // Let it throw out-of-bound here. This is by design to be
+  // consistent with NaiveViterbiSearch::AccumulatedCost
+  const auto& state = state_[id];
+
+  const auto it = scanned_labels_.find(state->id());
   if (it == scanned_labels_.end()) {
     return -1.f;
   } else {

--- a/valhalla/meili/viterbi_search.h
+++ b/valhalla/meili/viterbi_search.h
@@ -694,7 +694,8 @@ Time ViterbiSearch<T>::IterativeSearch(Time target, bool request_new_start)
     // Mark it as scanned and remember its cost and predecessor
     const auto& inserted = scanned_labels_.emplace(id, label);
     if (!inserted.second) {
-      throw std::logic_error("the principle of optimality is violated, probably negative costs occurred");
+      throw std::logic_error("the principle of optimality is violated in the viterbi search,"
+                             " probably negative costs occurred");
     }
 
     // Remove it from its column
@@ -726,6 +727,7 @@ Time ViterbiSearch<T>::IterativeSearch(Time target, bool request_new_start)
       winner_.push_back(state);
     }
 
+    // Update searched time
     searched_time = std::max(time, searched_time);
 
     // Break immediately when the winner at the target time is found.

--- a/valhalla/meili/viterbi_search.h
+++ b/valhalla/meili/viterbi_search.h
@@ -377,46 +377,26 @@ NaiveViterbiSearch<T, Maximize>::InitLabels(
 }
 
 
-template <typename U, bool Maximize>
-U FindExtremeElement(U begin, U end, double invalid_cost)
-{
-  U extreme_itr = end;
-
-  for (U itr = begin; itr != end; itr++) {
-    // Filter out invalid costs
-    if (invalid_cost == itr->costsofar) {
-      continue;
-    }
-
-    // Find the first extreme element
-    if (Maximize) {
-      if (extreme_itr == end || extreme_itr->costsofar < itr->costsofar) {
-        extreme_itr = itr;
-      }
-    } else {
-      if (extreme_itr == end || itr->costsofar < extreme_itr->costsofar) {
-        extreme_itr = itr;
-      }
-    }
-  }
-
-  return extreme_itr;
-}
-
-
 template <typename T, bool Maximize>
 const T*
 NaiveViterbiSearch<T, Maximize>::FindWinner(const std::vector<label_type>& labels) const
 {
-  if (labels.empty()) {
+  auto it = labels.cend();
+  if (Maximize) {
+    it = std::max_element(labels.cbegin(), labels.cend(), [](const label_type& left, const label_type& right) {
+        return left.costsofar < right.costsofar;
+      });
+  } else {
+    it = std::min_element(labels.cbegin(), labels.cend(), [](const label_type& left, const label_type& right) {
+        return left.costsofar < right.costsofar;
+      });
+  }
+  // The max label's costsofar is invalid (-infinity), that means all
+  // labels are invalid
+  if (it == labels.cend() || it->costsofar == kInvalidCost) {
     return nullptr;
   }
-  auto itr = FindExtremeElement<decltype(labels.cbegin()), Maximize>(labels.cbegin(), labels.cend(), kInvalidCost);
-  if (itr == labels.cend()) {
-    return nullptr;
-  }
-  assert(kInvalidCost != itr->costsofar);
-  return itr->state;
+  return it->state;
 }
 
 


### PR DESCRIPTION
This PR was intended to address #14 (fixes #14) to reduce asserts in the `routing.cc`. However it does more than this.

1. Follow @kevinkreiser advice all asserts in `routing.cc`, `viterbi_search.h`, and `priority_queue.h` were replaced with `logic_error` or `runtime_error` or just removed. In addition, comments on why they shouldn't happen added
2. Refactored `viterbi_search.h`. Code smell were either removed or improved.
3. Added comments wherever confusing

@kevinkreiser could you give it a review before merge?