### PR TITLE
MatchResult stores state id instead of the pointer

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -49,7 +49,8 @@ nobase_include_HEADERS = \
 	valhalla/meili/viterbi_search.h \
 	valhalla/meili/geojson_reader.h \
 	valhalla/meili/geojson_writer.h \
-	valhalla/meili/measurement.h
+	valhalla/meili/measurement.h \
+	valhalla/meili/match_result.h
 libvalhalla_meili_la_SOURCES = \
 	src/meili/universal_cost.cc \
 	src/meili/routing.cc \

--- a/docs/library_api.md
+++ b/docs/library_api.md
@@ -75,7 +75,7 @@ Here are some attributes:
 ```C++
 // Matched coordinate
 const valhalla::midgard::PointLL&
-mmp::MatchResult::matched_coordinate();
+mmp::MatchResult::lnglat();
 
 // Distance from measurement to the matched coordinate
 float mmp::MatchResult::distance();

--- a/src/meili/service.cc
+++ b/src/meili/service.cc
@@ -19,6 +19,7 @@
 #include "meili/map_matching.h"
 #include "meili/geojson_reader.h"
 #include "meili/geojson_writer.h"
+#include "meili/match_result.h"
 
 
 using namespace prime_server;

--- a/src/meili/valhalla_run_map_match.cc
+++ b/src/meili/valhalla_run_map_match.cc
@@ -19,10 +19,10 @@ int main(int argc, char *argv[])
   const std::string modename = config.get<std::string>("meili.mode");
 
   MapMatcherFactory matcher_factory(config);
-  auto matcher = matcher_factory.Create(modename);
+  auto mapmatcher = matcher_factory.Create(modename);
 
-  const float default_gps_accuracy = matcher->config().get<float>("gps_accuracy"),
-             default_search_radius = matcher->config().get<float>("search_radius");
+  const float default_gps_accuracy = mapmatcher->config().get<float>("gps_accuracy"),
+             default_search_radius = mapmatcher->config().get<float>("search_radius");
 
   std::vector<Measurement> measurements;
   std::string line;
@@ -34,16 +34,16 @@ int main(int argc, char *argv[])
 
       // Offline match
       std::cout << "Sequence " << index++ << std::endl;
-      const auto& results = matcher->OfflineMatch(measurements);
+      const auto& results = mapmatcher->OfflineMatch(measurements);
 
       // Show results
       size_t mmt_id = 0, count = 0;
       for (const auto& result : results) {
-        const auto state = result.state();
-        if (state) {
+        if (result.HasState()) {
+          const auto& state = mapmatcher->mapmatching().state(result.stateid());
           std::cout << mmt_id << " ";
-          std::cout << state->id() << " ";
-          std::cout << state->candidate().distance() << std::endl;
+          std::cout << state.id() << " ";
+          std::cout << state.candidate().distance() << std::endl;
           count++;
         }
         mmt_id++;
@@ -72,7 +72,7 @@ int main(int argc, char *argv[])
                               default_search_radius);
   }
 
-  delete matcher;
+  delete mapmatcher;
   matcher_factory.ClearCache();
 
   return 0;

--- a/valhalla/meili/geojson_reader.h
+++ b/valhalla/meili/geojson_reader.h
@@ -1,5 +1,4 @@
 // -*- mode: c++ -*-
-
 #ifndef MMP_GEOJSON_READER_H_
 #define MMP_GEOJSON_READER_H_
 
@@ -12,7 +11,6 @@
 
 
 namespace valhalla {
-
 namespace meili {
 
 class SequenceParseError: public std::runtime_error {

--- a/valhalla/meili/geojson_writer.h
+++ b/valhalla/meili/geojson_writer.h
@@ -1,5 +1,4 @@
 // -*- mode: c++ -*-
-
 #ifndef MMP_GEOJSON_WRITER_H_
 #define MMP_GEOJSON_WRITER_H_
 
@@ -19,7 +18,6 @@
 namespace {
 
 using namespace valhalla;
-
 
 template <typename buffer_t>
 void serialize_coordinate(rapidjson::Writer<buffer_t>& writer,
@@ -176,8 +174,8 @@ void serialize_verbose(rapidjson::Writer<buffer_t>& writer,
     writer.StartArray();
     if (result.HasState()) {
       const auto& state = mapmatching.state(result.stateid());
-      for (const auto state : mapmatching.states(state.time())) {
-        serialize_state(writer, *state, mapmatching);
+      for (const auto& other_state : mapmatching.states(state.time())) {
+        serialize_state(writer, *other_state, mapmatching);
       }
     }
     writer.EndArray();
@@ -190,9 +188,7 @@ void serialize_verbose(rapidjson::Writer<buffer_t>& writer,
 
 
 namespace valhalla {
-
 namespace meili {
-
 
 template <typename buffer_t>
 class GeoJSONWriter
@@ -455,8 +451,5 @@ void GeoJSONMatchedPointsWriter<buffer_t>::WriteProperties(rapidjson::Writer<buf
 }
 
 }
-
 }
-
-
 #endif // MMP_GEOJSON_WRITER_H_

--- a/valhalla/meili/geojson_writer.h
+++ b/valhalla/meili/geojson_writer.h
@@ -13,6 +13,7 @@
 #include <valhalla/baldr/graphid.h>
 
 #include <meili/map_matching.h>
+#include <meili/match_result.h>
 
 
 namespace {
@@ -150,10 +151,10 @@ void serialize_state(rapidjson::Writer<buffer_t>& writer,
 
 template <typename buffer_t>
 void serialize_verbose(rapidjson::Writer<buffer_t>& writer,
-                       meili::MapMatcher& matcher,
+                       const meili::MapMatcher& mapmatcher,
                        const std::vector<meili::MatchResult>& results)
 {
-  const auto& mm = matcher.mapmatching();
+  const auto& mapmatching = mapmatcher.mapmatching();
 
   writer.String("distances");
   writer.StartArray();
@@ -173,9 +174,10 @@ void serialize_verbose(rapidjson::Writer<buffer_t>& writer,
   writer.StartArray();
   for (const auto& result : results) {
     writer.StartArray();
-    if (result.state()) {
-      for (const auto state : mm.states(result.state()->time())) {
-        serialize_state(writer, *state, mm);
+    if (result.HasState()) {
+      const auto& state = mapmatching.state(result.stateid());
+      for (const auto state : mapmatching.states(state.time())) {
+        serialize_state(writer, *state, mapmatching);
       }
     }
     writer.EndArray();
@@ -355,7 +357,7 @@ void WriteRoute(rapidjson::Writer<buffer_t>& writer,
 
 template <typename buffer_t>
 void GeoJSONRouteWriter<buffer_t>::WriteGeometry(rapidjson::Writer<buffer_t>& writer,
-                                                 MapMatcher& matcher,
+                                                 MapMatcher& mapmatcher,
                                                  const std::vector<MatchResult>& results) const
 {
   writer.StartObject();
@@ -365,7 +367,11 @@ void GeoJSONRouteWriter<buffer_t>::WriteGeometry(rapidjson::Writer<buffer_t>& wr
 
   writer.String("coordinates");
   writer.StartArray();
-  WriteRoute(writer, matcher, ConstructRoute(matcher.graphreader(), results.cbegin(), results.cend()));
+  const auto& segments = ConstructRoute(mapmatcher.graphreader(),
+                                        mapmatcher,
+                                        results.cbegin(),
+                                        results.cend());
+  WriteRoute(writer, mapmatcher, segments);
   writer.EndArray();
 
   writer.EndObject();

--- a/valhalla/meili/map_matching.h
+++ b/valhalla/meili/map_matching.h
@@ -1,10 +1,8 @@
 // -*- mode: c++ -*-
 #ifndef MMP_MAP_MATCHING_H_
 #define MMP_MAP_MATCHING_H_
-
 #include <algorithm>
 
-#include <valhalla/midgard/logging.h>
 #include <valhalla/midgard/pointll.h>
 #include <valhalla/baldr/pathlocation.h>
 #include <valhalla/sif/edgelabel.h>
@@ -15,9 +13,10 @@
 #include <meili/candidate_search.h>
 #include <meili/viterbi_search.h>
 #include <meili/routing.h>
+#include <meili/match_result.h>
+
 
 namespace valhalla{
-
 namespace meili {
 
 
@@ -159,65 +158,6 @@ class MapMatching: public ViterbiSearch<State>
 };
 
 
-enum class GraphType: uint8_t
-{ kUnknown = 0, kEdge, kNode };
-
-
-class MatchResult
-{
- public:
-  MatchResult(const midgard::PointLL& lnglat,
-              float distance,
-              const baldr::GraphId graphid,
-              GraphType graphtype,
-              const State* state = nullptr)
-      : lnglat_(lnglat),
-        distance_(distance),
-        graphid_(graphid),
-        graphtype_(graphtype),
-        state_(state) {}
-
-  MatchResult(const midgard::PointLL& lnglat)
-      : lnglat_(lnglat),
-        distance_(0.f),
-        graphid_(),
-        graphtype_(GraphType::kUnknown),
-        state_(nullptr)
-  { }
-
-  // Coordinate of the matched point
-  const midgard::PointLL& lnglat() const
-  { return lnglat_; }
-
-  // Distance from measurement to the matched point
-  float distance() const
-  { return distance_; }
-
-  // Which edge/node this matched point stays
-  const baldr::GraphId graphid() const
-  { return graphid_; }
-
-  GraphType graphtype() const
-  { return graphtype_; }
-
-  // Attach the state pointer for other information (e.g. reconstruct
-  // the route path) and debugging
-  const State* state() const
-  { return state_; }
-
- private:
-  midgard::PointLL lnglat_;
-
-  float distance_;
-
-  baldr::GraphId graphid_;
-
-  GraphType graphtype_;
-
-  const State* state_;
-};
-
-
 struct EdgeSegment
 {
   EdgeSegment(baldr::GraphId the_edgeid,
@@ -235,40 +175,6 @@ struct EdgeSegment
 
   float target;
 };
-
-
-template <typename segment_iterator_t>
-std::string
-RouteToString(baldr::GraphReader& graphreader,
-              segment_iterator_t segment_begin,
-              segment_iterator_t segment_end,
-              const baldr::GraphTile*& tile);
-
-// Validate a route. It check if all edge segments of the route are
-// valid and successive, and no loop
-template <typename segment_iterator_t>
-bool ValidateRoute(baldr::GraphReader& graphreader,
-                   segment_iterator_t segment_begin,
-                   segment_iterator_t segment_end,
-                   const baldr::GraphTile*& tile);
-
-template <typename segment_iterator_t>
-void MergeRoute(std::vector<EdgeSegment>& route,
-                segment_iterator_t segment_begin,
-                segment_iterator_t segment_end);
-
-template <typename match_iterator_t>
-std::vector<EdgeSegment>
-ConstructRoute(baldr::GraphReader& graphreader,
-               match_iterator_t begin,
-               match_iterator_t end);
-
-inline float local_tile_size(const baldr::GraphReader& graphreader)
-{
-  const auto& tile_hierarchy = graphreader.GetTileHierarchy();
-  const auto& tiles = tile_hierarchy.levels().rbegin()->second.tiles;
-  return tiles.TileSize();
-}
 
 
 // A facade that connects everything
@@ -298,7 +204,7 @@ class MapMatcher final
   boost::property_tree::ptree config()
   { return config_; }
 
-  MapMatching& mapmatching()
+  const MapMatching& mapmatching() const
   { return mapmatching_; }
 
   std::vector<MatchResult>
@@ -384,10 +290,40 @@ private:
 };
 
 
+template <typename segment_iterator_t>
+std::string
+RouteToString(baldr::GraphReader& graphreader,
+              segment_iterator_t segment_begin,
+              segment_iterator_t segment_end,
+              const baldr::GraphTile*& tile);
+
+// Validate a route. It check if all edge segments of the route are
+// valid and successive, and no loop
+template <typename segment_iterator_t>
+bool ValidateRoute(baldr::GraphReader& graphreader,
+                   segment_iterator_t segment_begin,
+                   segment_iterator_t segment_end,
+                   const baldr::GraphTile*& tile);
+
+template <typename segment_iterator_t>
+void MergeRoute(std::vector<EdgeSegment>& route,
+                segment_iterator_t segment_begin,
+                segment_iterator_t segment_end);
+
+template <typename match_iterator_t>
+std::vector<EdgeSegment>
+ConstructRoute(baldr::GraphReader& graphreader,
+               const MapMatcher& mapmatcher,
+               match_iterator_t begin,
+               match_iterator_t end);
+
+inline float local_tile_size(const baldr::GraphReader& graphreader)
+{
+  const auto& tile_hierarchy = graphreader.GetTileHierarchy();
+  const auto& tiles = tile_hierarchy.levels().rbegin()->second.tiles;
+  return tiles.TileSize();
 }
 
 }
-
-
-
+}
 #endif // MMP_MAP_MATCHING_H_

--- a/valhalla/meili/match_result.h
+++ b/valhalla/meili/match_result.h
@@ -5,7 +5,7 @@
 #include <valhalla/midgard/pointll.h>
 #include <valhalla/baldr/graphid.h>
 
-#include <meili/viterbi_search.h>
+#include <valhalla/meili/viterbi_search.h>
 
 
 namespace valhalla {

--- a/valhalla/meili/match_result.h
+++ b/valhalla/meili/match_result.h
@@ -1,0 +1,76 @@
+// -*- mode: c++ -*-
+#ifndef MMP_MATCH_RESULT_H_
+#define MMP_MATCH_RESULT_H_
+
+#include <valhalla/midgard/pointll.h>
+#include <valhalla/baldr/graphid.h>
+
+#include <meili/viterbi_search.h>
+
+
+namespace valhalla {
+namespace meili {
+
+enum class GraphType: uint8_t
+{ kUnknown = 0, kEdge, kNode };
+
+
+class MatchResult
+{
+ public:
+  MatchResult(const midgard::PointLL& lnglat,
+              float distance,
+              const baldr::GraphId graphid,
+              GraphType graphtype,
+              StateId stateid)
+      : lnglat_(lnglat),
+        distance_(distance),
+        graphid_(graphid),
+        graphtype_(graphtype),
+        stateid_(stateid) {}
+
+  MatchResult(const midgard::PointLL& lnglat)
+      : lnglat_(lnglat),
+        distance_(0.f),
+        graphid_(),
+        graphtype_(GraphType::kUnknown),
+        stateid_(kInvalidStateId) {}
+
+  // Coordinate of the matched point
+  const midgard::PointLL& lnglat() const
+  { return lnglat_; }
+
+  // Distance from measurement to the matched point
+  float distance() const
+  { return distance_; }
+
+  // Which edge/node this matched point stays
+  const baldr::GraphId graphid() const
+  { return graphid_; }
+
+  GraphType graphtype() const
+  { return graphtype_; }
+
+  // Attach the state pointer for other information (e.g. reconstruct
+  // the route path) and debugging
+  StateId stateid() const
+  { return stateid_; }
+
+  bool HasState() const
+  { return stateid_ != kInvalidStateId; }
+
+ private:
+  midgard::PointLL lnglat_;
+
+  float distance_;
+
+  baldr::GraphId graphid_;
+
+  GraphType graphtype_;
+
+  StateId stateid_;
+};
+
+}
+}
+#endif // MMP_MATCH_RESULT_H_


### PR DESCRIPTION
Previously it was error-prone when the client of `MatchResult` tried to dereference the pointer to get the state object, without realizing that the `MapMatching` object had been destroyed.

Now you have to explicitly pass the state id to the `MapMatching` object to get the state object.

Other changes:
- and add `HasState()` to tell if the result is from a state (equivalent  to `state_ptr != nullptr`)
- and move it to `match_result.h` from `map_mathcing.h`