### PR TITLE
New grid traversal

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -67,7 +67,8 @@ nobase_include_HEADERS = \
 	valhalla/meili/geojson_writer.h \
 	valhalla/meili/measurement.h \
 	valhalla/meili/match_result.h \
-	valhalla/meili/bucket_queue.h
+	valhalla/meili/bucket_queue.h \
+	valhalla/meili/grid_traversal.h
 libvalhalla_meili_la_SOURCES = \
 	src/meili/universal_cost.cc \
 	src/meili/routing.cc \

--- a/Makefile.am
+++ b/Makefile.am
@@ -98,6 +98,7 @@ valhalla_meili_worker_LDADD = $(DEPS_LIBS) $(VALHALLA_DEPS_LIBS) @BOOST_LDFLAGS@
 check_PROGRAMS = \
 	test/geometry_helpers \
 	test/grid_range_query \
+	test/grid_traversal \
 	test/map_matching \
 	test/queue \
 	test/routing \
@@ -108,6 +109,10 @@ check_PROGRAMS = \
 test_geometry_helpers_SOURCES = test/geometry_helpers.cc test/test.cc
 test_geometry_helpers_CPPFLAGS = $(DEPS_CFLAGS) $(VALHALLA_DEPS_CFLAGS) @BOOST_CPPFLAGS@
 test_geometry_helpers_LDADD = $(DEPS_LIBS) $(VALHALLA_DEPS_LIBS) @BOOST_LDFLAGS@ libvalhalla_meili.la
+
+test_grid_traversal_SOURCES = test/grid_traversal.cc test/test.cc
+test_grid_traversal_CPPFLAGS = $(DEPS_CFLAGS) $(VALHALLA_DEPS_CFLAGS) @BOOST_CPPFLAGS@
+test_grid_traversal_LDADD = $(DEPS_LIBS) $(VALHALLA_DEPS_LIBS) @BOOST_LDFLAGS@ libvalhalla_meili.la
 
 test_grid_range_query_SOURCES = test/grid_range_query.cc test/test.cc
 test_grid_range_query_CPPFLAGS = $(DEPS_CFLAGS) $(VALHALLA_DEPS_CFLAGS) @BOOST_CPPFLAGS@

--- a/test/grid_range_query.cc
+++ b/test/grid_range_query.cc
@@ -123,6 +123,15 @@ void TestAddLineSegment()
   grid.AddLineSegment(0, LineSegment({0.5, 0.5}, {0.5, 0.5}));
   test::assert_bool(grid.GetItemsInCell(0, 0).size() == old_item00_size + 1,
                     "empty segment should be added");
+
+  // A special case that failed
+  {
+    BoundingBox bbox(-78.5, 0, -78.25, 0.25);
+    // 0.005 == 0.25 / 500 where 0.25 is the tile size and we divided it into 500x500 cells
+    GridRangeQuery<int> grid(bbox, 0.005f, 0.005f);
+    // Should not thow anything here
+    grid.AddLineSegment(1, LineSegment({-78.4831, 0.002865}, {-78.4839, -0.001577}));
+  }
 }
 
 

--- a/test/grid_range_query.cc
+++ b/test/grid_range_query.cc
@@ -6,96 +6,6 @@
 using namespace valhalla::meili;
 
 
-void TestGridTools()
-{
-  const BoundingBox bbox(0, 0, 100, 100);
-  GridRangeQuery<int> grid(bbox, 1.f, 1.f);
-
-  {
-    const auto c = grid.GridCoordinates({12.5, 13.7});
-    test::assert_bool(c.first == 12 && c.second == 13,
-                      "should get the right grid coodinate");
-  }
-
-  {
-    const auto intersects = BoundingBoxLineSegmentIntersections(grid.CellBoundingBox(2, 3),
-                                                                LineSegment({2.5, 3.5}, {10, 3.5}));
-    test::assert_bool(intersects.size() == 1, "should be intersected");
-    test::assert_bool(intersects[0].point.x() == 3 && intersects[0].point.y() == 3.5,
-                      "intersected coordinate should be correct");
-  }
-
-  {
-    const LineSegment segment({0, 0}, {100, 100});
-    LineSegment interior;
-    const auto ok = InteriorLineSegment(grid.bbox(), segment, interior);
-    test::assert_bool(ok && interior.a() == Point(0, 0) && interior.b() == Point(100, 100),
-                      "intersection should be LINESTRING(0 0, 100 100)");
-  }
-
-  {
-    const LineSegment segment({0, 0}, {50, 50});
-    LineSegment interior;
-    const auto ok = InteriorLineSegment(grid.bbox(), segment, interior);
-    test::assert_bool(ok && interior.a() == Point(0, 0) && interior.b() == Point(50, 50),
-                      "intersection should be LINESTRING(0 0, 50 50)");
-  }
-
-  {
-    const LineSegment segment({50, 50}, {150, 150});
-    LineSegment interior;
-    const auto ok = InteriorLineSegment(grid.bbox(), segment, interior);
-    test::assert_bool(ok && interior.a() == Point(50, 50) && interior.b() == Point(100, 100),
-                      "intersection should be LINESTRING(50 50, 100 100)");
-  }
-
-  {
-    const LineSegment segment({-50, -50}, {150, 150});
-    LineSegment interior;
-    const auto ok = InteriorLineSegment(grid.bbox(), segment, interior);
-    test::assert_bool(ok && interior.a() == Point(0, 0) && interior.b() == Point(100, 100),
-                      "intersection should be LINESTRING(0 0, 100 100)");
-  }
-
-  {
-    const LineSegment segment({100, 100}, {150, 150});
-    LineSegment interior;
-    const auto ok = InteriorLineSegment(grid.bbox(), segment, interior);
-    test::assert_bool(!ok, "Should be empty intersection");
-  }
-
-  {
-    const LineSegment segment({120, 120}, {150, 150});
-    LineSegment interior;
-    const auto ok = InteriorLineSegment(grid.bbox(), segment, interior);
-    test::assert_bool(!ok, "Should be empty intersection");
-  }
-
-  {
-    const LineSegment segment({20, 20}, {80, 80});
-    LineSegment interior;
-    const auto ok = InteriorLineSegment(grid.bbox(), segment, interior);
-    test::assert_bool(ok && interior.a() == Point(20, 20) && interior.b() == Point(80, 80),
-                      "intersection should be LINESTRING(20 20, 80 80)");
-  }
-
-  {
-    const LineSegment segment({20, 20}, {20, 20});
-    LineSegment interior;
-    const auto ok = InteriorLineSegment(grid.bbox(), segment, interior);
-    test::assert_bool(ok && interior.a() == Point(20, 20) && interior.b() == Point(20, 20),
-                      "intersection should be LINESTRING(20 20, 20 20)");
-  }
-
-  {
-    const LineSegment segment({200, 200}, {200, 200});
-    LineSegment interior;
-    const auto ok = InteriorLineSegment(grid.bbox(), segment, interior);
-    test::assert_bool(!ok, "should be empty intersection");
-  }
-}
-
-
 void TestAddLineSegment()
 {
   BoundingBox bbox(0, 0, 100, 100);
@@ -158,8 +68,6 @@ void TestQuery()
 int main(int argc, char *argv[])
 {
   test::suite suite("grid range query");
-
-  suite.test(TEST_CASE(TestGridTools));
 
   suite.test(TEST_CASE(TestAddLineSegment));
 

--- a/test/grid_traversal.cc
+++ b/test/grid_traversal.cc
@@ -1,0 +1,168 @@
+#include <iostream>
+#include <vector>
+#include <tuple>
+
+#include <valhalla/midgard/point2.h>
+#include <valhalla/midgard/linesegment2.h>
+
+#include "meili/grid_traversal.h"
+#include "test.h"
+
+using namespace valhalla;
+
+
+bool equal_squares(const std::vector<std::pair<int, int>>& s1,
+                   const std::vector<std::pair<int, int>>& s2)
+{
+  bool ok = s1.size() == s2.size();
+  if (!ok) return false;
+
+  for (decltype(s1.size()) i=0; i < s1.size(); i++) {
+    ok = s1[i].first == s2[i].first && s1[i].second == s2[i].second;
+    if (!ok) return false;
+  }
+
+  return true;
+}
+
+
+void assert_equal_squares(const std::vector<std::pair<int, int>>& got,
+                          const std::vector<std::pair<int, int>>& expected,
+                          const std::string& msg)
+{
+  std::string got_ss;
+  got_ss = "(";
+  for (const auto& p: got) {
+    got_ss += std::to_string(p.first);
+    got_ss += " ";
+    got_ss += std::to_string(p.second);
+    got_ss += ", ";
+  }
+  if (1 < got_ss.size()) {
+    got_ss.erase(got_ss.size() - 2);
+  }
+  got_ss += ")";
+
+  std::string expected_ss;
+  expected_ss = "(";
+  for (const auto& p: expected) {
+    expected_ss += std::to_string(p.first);
+    expected_ss += " ";
+    expected_ss += std::to_string(p.second);
+    expected_ss += ", ";
+  }
+  if (1 < expected_ss.size()) {
+    expected_ss.erase(expected_ss.size() - 2);
+  }
+  expected_ss += ")";
+
+  test::assert_bool(equal_squares(got, expected),
+                    msg + ". Expected " + expected_ss + ", but got " + got_ss);
+}
+
+
+void TestGridTraversal()
+{
+  meili::GridTraversal<midgard::Point2> grid(0.1, 0.1, 0.3, 0.3, 3, 3);
+  assert_equal_squares(grid.Traverse({{0, 0}, {0.9, 0.9}}),
+                       std::vector<std::pair<int, int>>{{0, 0}, {1, 1}, {2, 2}},
+                       "It should intersect squares in diagonal");
+
+  assert_equal_squares(grid.Traverse({{0, 0}, {0.5, 0.5}}),
+                       std::vector<std::pair<int, int>>{{0, 0}, {1, 1}},
+                       "It should intersect squares in diagonal");
+
+  assert_equal_squares(grid.Traverse({{0.2, 0.25}, {0.89, 0.32}}),
+                       std::vector<std::pair<int, int>>{{0, 0}, {1, 0}, {2, 0}},
+                       "It should intersect bottom squares");
+
+  assert_equal_squares(grid.Traverse({{0.2, 0.25}, {0.34, 0.83}}),
+                       std::vector<std::pair<int, int>>{{0, 0}, {0, 1}, {0, 2}},
+                       "It should intersect leftmost squares");
+
+  assert_equal_squares(grid.Traverse({{0.3, 0.25}, {0.98, 0.83}}),
+                       std::vector<std::pair<int, int>>{{0, 0}, {1, 0}, {1, 1}, {2, 1}, {2, 2}},
+                       "It should intersect sqaures from SQUARE(0 0) to SQUARE(2 2) in the lower side way");
+
+  assert_equal_squares(grid.Traverse({{-1, 0.1}, {2, 0.1}}),
+                       std::vector<std::pair<int, int>>{{0, 0}, {1, 0}, {2, 0}},
+                       "It should intersect bottom grid line");
+
+  assert_equal_squares(grid.Traverse({{0.1, -1}, {0.1, 2}}),
+                       std::vector<std::pair<int, int>>{{0, 0}, {0, 1}, {0, 2}},
+                       "It should intersect leftmost grid line");
+
+  assert_equal_squares(grid.Traverse({{0.1, 0.1}, {0.1, 0.1}}),
+                       std::vector<std::pair<int, int>>{{0, 0}},
+                       "Single point at left bottom corner should intersect SQUARE(0 0)");
+
+  assert_equal_squares(grid.Traverse({{0.5, 0.5}, {0.5, 0.5}}),
+                       std::vector<std::pair<int, int>>{{1, 1}},
+                       "Single point should intersect SQUARE(1 1)");
+
+  assert_equal_squares(grid.Traverse({{0, 0}, {0, 0}}),
+                       std::vector<std::pair<int, int>>{},
+                       "Single point outside grid should not intersect");
+
+  assert_equal_squares(grid.Traverse({{0, 0}, {0.1, 0.2}}),
+                       std::vector<std::pair<int, int>>{{0, 0}},
+                       "It should intersect SQUARE(0 0)");
+  assert_equal_squares(grid.Traverse({{0, 0}, {0.2, 0.1}}),
+                       std::vector<std::pair<int, int>>{{0, 0}},
+                       "It should intersect SQUARE(0 0)");
+
+  assert_equal_squares(grid.Traverse({{2, 1}, {0.5, 0.5}}),
+                       std::vector<std::pair<int, int>>{{2, 1}, {1, 1}},
+                       "It should partially intersect from right side");
+
+  assert_equal_squares(grid.Traverse({{0, 0}, {0.07, 0.08}}),
+                       std::vector<std::pair<int, int>>{},
+                       "A line segment completely outside the grid should not intersect");
+
+
+  // Test a grid that can be precisely expressed by floating-point
+  // number
+  meili::GridTraversal<midgard::Point2> perfect_grid(0.5, 0.5, 0.25, 0.25, 3, 3);
+
+  assert_equal_squares(perfect_grid.Traverse({{1.25, 1.25}, {1.25, 1.25}}),
+                       std::vector<std::pair<int, int>>{},
+                       "Sit on the rightmost grid line but it is actually outside the grid");
+
+  assert_equal_squares(perfect_grid.Traverse({{1, 1}, {1, 1}}),
+                       std::vector<std::pair<int, int>>{{2, 2}},
+                       "Sit on the corner of SQUARE(2 2)");
+
+  assert_equal_squares(perfect_grid.Traverse({{1, 0}, {1, 2}}),
+                       std::vector<std::pair<int, int>>{{2, 0}, {2, 1}, {2, 2}},
+                       "Parallel to vertical grid lines");
+  assert_equal_squares(perfect_grid.Traverse({{1.05, 0}, {1.05, 2}}),
+                       std::vector<std::pair<int, int>>{{2, 0}, {2, 1}, {2, 2}},
+                       "Parallel to vertical grid lines");
+  assert_equal_squares(perfect_grid.Traverse({{1.25, 0}, {1.25, 2}}),
+                       std::vector<std::pair<int, int>>{},
+                       "Parallel to vertical grid lines");
+
+  assert_equal_squares(perfect_grid.Traverse({{0, 1}, {2, 1}}),
+                       std::vector<std::pair<int, int>>{{0, 2}, {1, 2}, {2, 2}},
+                       "Parallel to horizontal grid lines");
+  assert_equal_squares(perfect_grid.Traverse({{0, 1.05}, {2, 1.05}}),
+                       std::vector<std::pair<int, int>>{{0, 2}, {1, 2}, {2, 2}},
+                       "Parallel to horizontal grid lines");
+  assert_equal_squares(perfect_grid.Traverse({{0, 1.25}, {2, 1.25}}),
+                       std::vector<std::pair<int, int>>{},
+                       "Parallel to horizontal grid lines");
+
+  assert_equal_squares(perfect_grid.Traverse({{1.25, 1}, {1.25, 1}}),
+                       std::vector<std::pair<int, int>>{},
+                       "Single point sit on rightmost grid line");
+}
+
+
+int main(int argc, char *argv[])
+{
+  test::suite suite("grid traversal");
+
+  suite.test(TEST_CASE(TestGridTraversal));
+
+  return suite.tear_down();
+}

--- a/valhalla/meili/grid_range_query.h
+++ b/valhalla/meili/grid_range_query.h
@@ -188,7 +188,14 @@ class GridRangeQuery
             bbox_.miny() + (j + 0.5) * cell_height_}; }
 
   const std::vector<key_t>& GetItemsInCell(int i, int j) const
-  { return items_[i + j * num_cols_]; }
+  {
+    if (!(0 <= i && i < num_rows_) || !(0 <= j && j < num_cols_)) {
+      throw std::runtime_error("Cell index (" + std::to_string(i)  + ", " + std::to_string(j)
+                               + ") is out of the grid bounds (" + std::to_string(num_rows_) + "x"
+                               + std::to_string(num_cols_) + ")");
+    }
+    return items_[i + j * num_cols_];
+  }
 
   // Index a line segment into the grid
   void AddLineSegment(const key_t edgeid, const LineSegment& segment)
@@ -268,7 +275,14 @@ class GridRangeQuery
   { return BoundingBoxLineSegmentIntersections(CellBoundingBox(i, j), segment); }
 
   std::vector<key_t>& ItemsInCell(int i, int j)
-  { return items_[i + j * num_cols_]; }
+  {
+    if (!(0 <= i && i < num_rows_) || !(0 <= j && j < num_cols_)) {
+      throw std::runtime_error("Cell index (" + std::to_string(i)  + ", " + std::to_string(j)
+                               + ") is out of the grid bounds (" + std::to_string(num_rows_) + "x"
+                               + std::to_string(num_cols_) + " cells)");
+    }
+    return items_[i + j * num_cols_];
+  }
 
   BoundingBox bbox_;
   float cell_width_;

--- a/valhalla/meili/grid_range_query.h
+++ b/valhalla/meili/grid_range_query.h
@@ -15,6 +15,8 @@
 #include <valhalla/midgard/linesegment2.h>
 #include <valhalla/midgard/distanceapproximator.h>
 
+#include <valhalla/meili/grid_traversal.h>
+
 
 namespace valhalla{
 namespace meili {
@@ -24,225 +26,50 @@ using LineSegment = midgard::LineSegment2<Point>;
 using BoundingBox = midgard::AABB2<Point>;
 
 
-// Represents one intersection beetween one side of a bounding box and a segment
-struct BoundingBoxIntersection {
-  BoundingBoxIntersection() = default;
-
-  BoundingBoxIntersection(const Point& pt, int8_t x, int8_t y)
-      : point(pt), dx(x), dy(y) {}
-
-  Point point;  // The intersection point
-  int8_t dx, dy;   // The direction to the cell adjacent to the intersected side
-};
-
-
-inline std::vector<BoundingBoxIntersection>
-BoundingBoxLineSegmentIntersections(const BoundingBox &box, const LineSegment &segment)
-{
-  std::vector<BoundingBoxIntersection> intersects;
-  intersects.reserve(4);
-
-  LineSegment e1({box.minx(), box.miny()}, {box.maxx(), box.miny()});
-  LineSegment e2({box.maxx(), box.miny()}, {box.maxx(), box.maxy()});
-  LineSegment e3({box.maxx(), box.maxy()}, {box.minx(), box.maxy()});
-  LineSegment e4({box.minx(), box.maxy()}, {box.minx(), box.miny()});
-
-  Point intersect;
-  if (segment.Intersect(e1, intersect))
-    intersects.emplace_back(intersect, 0, -1);
-  if (segment.Intersect(e2, intersect))
-    intersects.emplace_back(intersect, 1, 0);
-  if (segment.Intersect(e3, intersect))
-    intersects.emplace_back(intersect, 0, 1);
-  if (segment.Intersect(e4, intersect))
-    intersects.emplace_back(intersect, -1, 0);
-
-  return intersects;
-}
-
-
-// Return t such that p = a + t * (b - a)
-inline float
-Unlerp(const Point &a, const Point &b, const Point &p)
-{
-  if (std::abs(b.y() - a.y()) < std::abs(b.x() - a.x())) {
-    return (p.x() - a.x()) / (b.x() - a.x());
-  } else {
-    return (p.y() - a.y()) / (b.y() - a.y());
-  }
-}
-
-
-inline bool
-InteriorLineSegment(const BoundingBox& bbox,
-                    const LineSegment &segment,
-                    LineSegment &interior)
-{
-  const Point& a = segment.a();
-  const Point& b = segment.b();
-
-  if (a == b) {
-    if (bbox.Contains(a)) {
-      interior = LineSegment(a, b);
-      return true;
-    } else {
-      return false;
-    }
-  }
-
-  const auto& intersects = BoundingBoxLineSegmentIntersections(bbox, LineSegment(a, b));
-  std::vector<Point> points;
-  points.reserve(4 + 2);
-  for (const auto &i : intersects) points.push_back(i.point);
-
-  if (bbox.Contains(a)) points.push_back(a);
-  if (bbox.Contains(b)) points.push_back(b);
-
-  float mint = 1, maxt = 0;
-  Point minp, maxp;
-  for (const auto &p : points) {
-    const float t = Unlerp(a, b, p);
-    if (t < mint) {
-      mint = t;
-      minp = p;
-    }
-    if (t > maxt) {
-      maxt = t;
-      maxp = p;
-    }
-  }
-
-  if (mint < 1 && maxt > 0) {
-    // assert(mint <= maxt);
-    interior = LineSegment(minp, maxp);
-    return true;
-  } else {
-    return false;
-  }
-}
-
-
 template <typename key_t>
 class GridRangeQuery
 {
  public:
-  GridRangeQuery() = delete;
-
-  GridRangeQuery(const BoundingBox& bbox, float cell_width, float cell_height)
-  {
-    if (cell_width <= 0.f) {
-      throw std::invalid_argument("invalid cell width (require positive width)");
-    }
-    if (cell_height <= 0.f) {
-      throw std::invalid_argument("invalid cell height (require positive height)");
-    }
-    auto bbox_width = bbox.Width();
-    if (bbox_width <= 0.f) {
-      throw std::invalid_argument("invalid bounding box (require positive width)");
-    }
-    auto bbox_height = bbox.Height();
-    if (bbox_height <= 0.f) {
-      throw std::invalid_argument("invalid bounding box (require positive height)");
-    }
-    bbox_ = bbox;
-    cell_width_ = std::min(bbox_width, cell_width);
-    cell_height_ = std::min(bbox_height, cell_height);
-    num_rows_ = ceil(bbox_width / cell_width_);
-    num_cols_ = ceil(bbox_height / cell_height_);
-    items_.resize(num_cols_ * num_rows_);
-  }
+  GridRangeQuery(const BoundingBox& bbox, float square_width, float square_height):
+      bbox_(bbox),
+      square_width_(square_width),
+      square_height_(square_height),
+      ncols_((bbox.maxx() - bbox.minx()) / square_width),
+      nrows_((bbox.maxy() - bbox.miny()) / square_height),
+      traverser_(bbox.minx(), bbox.miny(), square_width, square_height, ncols_, nrows_),
+      items_()
+  { items_.resize(ncols_ * nrows_); }
 
   const BoundingBox& bbox() const
   { return bbox_; }
 
-  int num_rows() const
-  { return num_rows_; }
+  int nrows() const
+  { return nrows_; }
 
-  int num_cols() const
-  { return num_cols_; }
+  int ncols() const
+  { return ncols_; }
 
-  float cell_width() const
-  { return cell_width_; }
+  float square_width() const
+  { return square_width_; }
 
-  float cell_height() const
-  { return cell_height_; }
-
-  std::pair<int, int> GridCoordinates(const Point &p) const
-  {
-    const float dx = p.x() - bbox_.minx();
-    const float dy = p.y() - bbox_.miny();
-    return { int(dx / cell_width_), int(dy / cell_height_) };
-  }
-
-  BoundingBox CellBoundingBox(int i, int j) const
-  {
-    return BoundingBox(
-        bbox_.minx() + i * cell_width_,
-        bbox_.miny() + j * cell_height_,
-        bbox_.minx() + (i + 1) * cell_width_,
-        bbox_.miny() + (j + 1) * cell_height_);
-  }
-
-  Point CellCenter(int i, int j) const
-  { return {bbox_.minx() + (i + 0.5) * cell_width_,
-            bbox_.miny() + (j + 0.5) * cell_height_}; }
+  float square_height() const
+  { return square_height_; }
 
   const std::vector<key_t>& GetItemsInCell(int i, int j) const
   {
-    if (!(0 <= i && i < num_rows_) || !(0 <= j && j < num_cols_)) {
+    if (!(0 <= i && i < nrows_) || !(0 <= j && j < ncols_)) {
       throw std::runtime_error("Cell index (" + std::to_string(i)  + ", " + std::to_string(j)
-                               + ") is out of the grid bounds (" + std::to_string(num_rows_) + "x"
-                               + std::to_string(num_cols_) + ")");
+                               + ") is out of the grid bounds (" + std::to_string(nrows_) + "x"
+                               + std::to_string(ncols_) + ")");
     }
-    return items_[i + j * num_cols_];
+    return items_[i + j * ncols_];
   }
 
   // Index a line segment into the grid
   void AddLineSegment(const key_t edgeid, const LineSegment& segment)
   {
-    LineSegment interior;
-
-    // Do nothing if segment is completely outside the box
-    if (!InteriorLineSegment(bbox_, segment, interior)) return;
-
-    const Point& start = interior.a();
-    const Point& end = interior.b();
-
-    Point current_point = start;
-    int i, j;
-    std::tie(i, j) = GridCoordinates(current_point);
-
-    // Special case
-    if (start == end) {
-      ItemsInCell(i, j).push_back(edgeid);
-      return;
-    }
-
-    const midgard::DistanceApproximator approximator(end);
-
-    // Walk along start, end
-    while (Unlerp(start, end, current_point) < 1.0) {
-      ItemsInCell(i, j).push_back(edgeid);
-
-      const auto initiald = approximator.DistanceSquared(CellCenter(i, j));
-      auto bestd = initiald;
-
-      BoundingBoxIntersection bestp;
-      for (const auto& intersect : CellLineSegmentIntersections(i, j, LineSegment(current_point, end))) {
-        const auto d = approximator.DistanceSquared(CellCenter(i + intersect.dx, j + intersect.dy));
-        if (d < bestd) {
-          bestd = d;
-          bestp = intersect;
-        }
-      }
-
-      if (bestd < initiald) {
-        current_point = bestp.point;
-        i += bestp.dx;
-        j += bestp.dy;
-      } else {
-        break;
-      }
+    for (const auto& square: traverser_.Traverse(segment)) {
+      ItemsInCell(square.first, square.second).push_back(edgeid);
     }
   }
 
@@ -251,13 +78,13 @@ class GridRangeQuery
     std::unordered_set<key_t> results;
 
     int mini, minj, maxi, maxj;
-    std::tie(mini, minj) = GridCoordinates(range.minpt());
-    std::tie(maxi, maxj) = GridCoordinates(range.maxpt());
+    std::tie(mini, minj) = traverser_.SquareAtPoint(range.minpt());
+    std::tie(maxi, maxj) = traverser_.SquareAtPoint(range.maxpt());
 
-    mini = std::max(0, std::min(mini, num_cols_ - 1));
-    maxi = std::max(0, std::min(maxi, num_cols_ - 1));
-    minj = std::max(0, std::min(minj, num_rows_ - 1));
-    maxj = std::max(0, std::min(maxj, num_rows_ - 1));
+    mini = std::max(0, std::min(mini, ncols_ - 1));
+    maxi = std::max(0, std::min(maxi, ncols_ - 1));
+    minj = std::max(0, std::min(minj, nrows_ - 1));
+    maxj = std::max(0, std::min(maxj, nrows_ - 1));
 
     for (int i = mini; i <= maxi; ++i) {
       for (int j = minj; j <= maxj; ++j) {
@@ -270,25 +97,22 @@ class GridRangeQuery
   }
 
  private:
-  std::vector<BoundingBoxIntersection>
-  CellLineSegmentIntersections(int i, int j, const LineSegment &segment) const
-  { return BoundingBoxLineSegmentIntersections(CellBoundingBox(i, j), segment); }
-
   std::vector<key_t>& ItemsInCell(int i, int j)
   {
-    if (!(0 <= i && i < num_rows_) || !(0 <= j && j < num_cols_)) {
+    if (!(0 <= i && i < nrows_) || !(0 <= j && j < ncols_)) {
       throw std::runtime_error("Cell index (" + std::to_string(i)  + ", " + std::to_string(j)
-                               + ") is out of the grid bounds (" + std::to_string(num_rows_) + "x"
-                               + std::to_string(num_cols_) + " cells)");
+                               + ") is out of the grid bounds (" + std::to_string(nrows_) + "x"
+                               + std::to_string(ncols_) + " cells)");
     }
-    return items_[i + j * num_cols_];
+    return items_[i + j * ncols_];
   }
 
   BoundingBox bbox_;
-  float cell_width_;
-  float cell_height_;
-  int num_rows_;
-  int num_cols_;
+  float square_width_;
+  float square_height_;
+  int ncols_;
+  int nrows_;
+  GridTraversal<Point> traverser_;
   std::vector<std::vector<key_t> > items_;
 };
 

--- a/valhalla/meili/grid_traversal.h
+++ b/valhalla/meili/grid_traversal.h
@@ -195,7 +195,7 @@ class GridTraversal
 
   float minx_, miny_, maxx_, maxy_;
   float square_width_, square_height_;
-  unsigned ncols_, nrows_;
+  int ncols_, nrows_;
 };
 
 }

--- a/valhalla/meili/grid_traversal.h
+++ b/valhalla/meili/grid_traversal.h
@@ -4,6 +4,7 @@
 
 #include <vector>
 #include <cmath>
+#include <limits>
 
 #include <valhalla/midgard/pointll.h>
 #include <valhalla/midgard/linesegment2.h>
@@ -41,8 +42,12 @@ class GridTraversal
   std::vector<std::pair<int, int> >
   Traverse(const midgard::LineSegment2<coord_t>& segment) const
   {
-    const float tangent = (segment.b().y() - segment.a().y()) / (segment.b().x() - segment.a().x()),
-              cotangent = 1.0 / tangent;
+    // Division by zero is undefined in C++, here we ensure it to be
+    // infinity
+    const float height = segment.b().y() - segment.a().y(),
+                 width = segment.b().x() - segment.a().x(),
+               tangent = width == 0.f? std::numeric_limits<float>::infinity() : (height / width),
+             cotangent = height == 0.f? std::numeric_limits<float>::infinity() : (width / height);
 
     int col, row, dest_col, dest_row;
     std::tie(col, row) = StartSquare(segment, tangent, cotangent);
@@ -138,7 +143,8 @@ class GridTraversal
   std::pair<int, int>
   StartSquare(const midgard::LineSegment2<coord_t>& segment, float tangent, float cotangent) const
   {
-    const auto& origin = segment.a(), &dest = segment.b();
+    const auto &origin = segment.a(),
+                 &dest = segment.b();
 
     // Return the square if origin point falls inside the grid
     int col, row;

--- a/valhalla/meili/grid_traversal.h
+++ b/valhalla/meili/grid_traversal.h
@@ -33,7 +33,8 @@ class GridTraversal
   {
     const float dx = pt.x() - minx_,
                 dy = pt.y() - miny_;
-    return { int(dx / square_width_), int(dy / square_height_) };
+    return {static_cast<int>(floor(dx / square_width_)),
+            static_cast<int>(floor(dy / square_height_))};
   }
 
   bool IsValidSquare(int col, int row) const

--- a/valhalla/meili/grid_traversal.h
+++ b/valhalla/meili/grid_traversal.h
@@ -1,0 +1,196 @@
+// -*- mode: c++ -*-
+#ifndef MMP_GRID_TRAVERSAL_H_
+#define MMP_GRID_TRAVERSAL_H_
+
+#include <vector>
+#include <cmath>
+
+#include <valhalla/midgard/pointll.h>
+#include <valhalla/midgard/linesegment2.h>
+
+
+namespace valhalla{
+namespace meili {
+
+template <typename coord_t>
+class GridTraversal
+{
+ public:
+  GridTraversal(float minx, float miny,
+                float square_width, float square_height,
+                int ncols, int nrows)
+      : minx_(minx),
+        miny_(miny),
+        maxx_(minx + square_width * ncols),
+        maxy_(miny + square_height * nrows),
+        square_width_(square_width),
+        square_height_(square_height),
+        ncols_(ncols),
+        nrows_(nrows) {}
+
+  std::pair<int, int> SquareAtPoint(const coord_t &pt) const
+  {
+    const float dx = pt.x() - minx_,
+                dy = pt.y() - miny_;
+    return { int(dx / square_width_), int(dy / square_height_) };
+  }
+
+  bool IsValidSquare(int col, int row) const
+  { return 0 <= col && col < ncols_ && 0 <= row && row < nrows_; }
+
+  std::vector<std::pair<int, int> >
+  Traverse(const midgard::LineSegment2<coord_t>& segment) const
+  {
+    const float tangent = (segment.b().y() - segment.a().y()) / (segment.b().x() - segment.a().x()),
+              cotangent = 1.0 / tangent;
+
+    int col, row, dest_col, dest_row;
+    std::tie(col, row) = StartSquare(segment, tangent, cotangent);
+    std::tie(dest_col, dest_row) = SquareAtPoint(segment.b());
+
+    // Append intersecting squares
+    std::vector<std::pair<int, int>> squares;
+    while (!(col == dest_col && row == dest_row) && IsValidSquare(col, row)) {
+      squares.emplace_back(col, row);
+
+      // Calculating next intersecting square
+
+      // Intersect with the right border of the square
+      if (col < dest_col && IntersectsRow(segment.a(), tangent, col + 1) == row) {
+        col++;
+        continue;
+      }
+      // Intersect with the left border of the square
+      if (dest_col < col && IntersectsRow(segment.a(), tangent, col) == row) {
+        col--;
+        continue;
+      }
+      // Intersect with the top border of the square
+      if (row < dest_row && IntersectsColumn(segment.a(), cotangent, row + 1) == col) {
+        row++;
+        continue;
+      }
+      // Intersect with the bottom border of the square
+      if (dest_row < row && IntersectsColumn(segment.a(), cotangent, row) == col) {
+        row--;
+        continue;
+      }
+
+      // Move along a diagonal line if no intersecting squares found
+      // among four neighbors
+      if (col < dest_col) {
+        col++;
+      } else if (dest_col < col) {
+        col--;
+      }
+      if (row < dest_row) {
+        row++;
+      } else if (dest_row < row) {
+        row--;
+      }
+    }
+
+    // Append the last square
+    if (IsValidSquare(col, row)) {
+      squares.emplace_back(col, row);
+    }
+
+    return squares;
+  }
+
+ private:
+  int IntersectsColumn(const coord_t& origin, float cotangent, int row) const
+  {
+    // The origin and the cotangent define a ray.
+
+    // If the ray is parallel with horizontal grid lines, return an
+    // invalid column
+    if (std::isinf(cotangent)) {
+      return -1;
+    }
+    // (intersect_x, intersect_y) is the intersecting point of the ray
+    // and the bottom horizontal grid line at the specified row
+    const float intersect_y = miny_ + row * square_height_;
+    // Since we have (intersect_x - origin.x()) / (intersect_y - origin.y()) == cotangent
+    const float intersect_x = (intersect_y - origin.y()) * cotangent + origin.x();
+    // Return the intersecting column
+    return (intersect_x - minx_) / square_width_;
+  }
+
+  int IntersectsRow(const coord_t& origin, float tangent, int col) const
+  {
+    // The origin and the tangent define a ray.
+
+    // If the ray is parallel with vertical grid lines, return an
+    // invalid row
+    if (std::isinf(tangent)) {
+      return -1;
+    }
+    // (intersect_x, intersect_y) is the intersecting point of the ray
+    // and the left vertical grid line at the specified column
+    const float intersect_x = minx_ + col * square_width_;
+    // Since we have (intersect_y - origin.y()) / (intersect_x - origin.x()) == tangent
+    const float intersect_y = (intersect_x - origin.x()) * tangent + origin.y();
+    // Return the intersecting row
+    return (intersect_y - miny_) / square_height_;
+  }
+
+  std::pair<int, int>
+  StartSquare(const midgard::LineSegment2<coord_t>& segment, float tangent, float cotangent) const
+  {
+    const auto& origin = segment.a(), &dest = segment.b();
+
+    // Return the square if origin point falls inside the grid
+    int col, row;
+    std::tie(col, row) = SquareAtPoint(origin);
+    if (IsValidSquare(col, row)) {
+      return {col, row};
+    }
+
+    // If it falls outside the grid, then we find the first
+    // intersecting square along the segment
+
+    // Left side of the grid
+    if (origin.x() < minx_) {
+      const auto left_row = IntersectsRow(origin, tangent, 0);
+      if (minx_ <= dest.x() && IsValidSquare(0, left_row)) {
+        return {0, left_row};
+      }
+    }
+    // Right side of the grid
+    else {
+      // Assert maxx_ <= origin.x()
+      const auto right_row = IntersectsRow(origin, tangent, ncols_ - 1);
+      if (dest.x() < maxx_ && IsValidSquare(ncols_ - 1, right_row)) {
+        return {ncols_ - 1, right_row};
+      }
+    }
+
+    // Bottom side of the grid
+    if (origin.y() < miny_) {
+      const auto bottom_col = IntersectsColumn(origin, cotangent, nrows_ - 1);
+      if (miny_ <= dest.y() && IsValidSquare(bottom_col, 0)) {
+        return {bottom_col, 0};
+      }
+    }
+    // Top side of the grid
+    else {
+      // Assert maxy_ <= origin.y()
+      const auto top_col = IntersectsColumn(origin, cotangent, 0);
+      if (dest.y() < maxy_ && IsValidSquare(top_col, nrows_ - 1)) {
+        return {top_col, nrows_ - 1};
+      }
+    }
+
+    // Not intersecting the grid
+    return {-1, -1};
+  }
+
+  float minx_, miny_, maxx_, maxy_;
+  float square_width_, square_height_;
+  unsigned ncols_, nrows_;
+};
+
+}
+}
+#endif // MMP_GRID_TRAVERSAL_H_

--- a/valhalla/meili/grid_traversal.h
+++ b/valhalla/meili/grid_traversal.h
@@ -120,7 +120,7 @@ class GridTraversal
     // Since we have (intersect_x - origin.x()) / (intersect_y - origin.y()) == cotangent
     const float intersect_x = (intersect_y - origin.y()) * cotangent + origin.x();
     // Return the intersecting column
-    return (intersect_x - minx_) / square_width_;
+    return floor((intersect_x - minx_) / square_width_);
   }
 
   int IntersectsRow(const coord_t& origin, float tangent, int col) const
@@ -138,7 +138,7 @@ class GridTraversal
     // Since we have (intersect_y - origin.y()) / (intersect_x - origin.x()) == tangent
     const float intersect_y = (intersect_x - origin.x()) * tangent + origin.y();
     // Return the intersecting row
-    return (intersect_y - miny_) / square_height_;
+    return floor((intersect_y - miny_) / square_height_);
   }
 
   std::pair<int, int>
@@ -175,7 +175,7 @@ class GridTraversal
 
     // Bottom side of the grid
     if (origin.y() < miny_) {
-      const auto bottom_col = IntersectsColumn(origin, cotangent, nrows_ - 1);
+      const auto bottom_col = IntersectsColumn(origin, cotangent, 0);
       if (miny_ <= dest.y() && IsValidSquare(bottom_col, 0)) {
         return {bottom_col, 0};
       }
@@ -183,7 +183,7 @@ class GridTraversal
     // Top side of the grid
     else {
       // Assert maxy_ <= origin.y()
-      const auto top_col = IntersectsColumn(origin, cotangent, 0);
+      const auto top_col = IntersectsColumn(origin, cotangent, nrows_ - 1);
       if (dest.y() < maxy_ && IsValidSquare(top_col, nrows_ - 1)) {
         return {top_col, nrows_ - 1};
       }


### PR DESCRIPTION
This PR implemented a new grid traversal algorithm, with a simple interface:

```C++
// return a list of square coordinates that interest the line segment
std::vector<std::pair<int, int>>
GridTraversal::Traverse(const LineSegment& segment);
```

It replaced the same functionality implemented in `GridRangeSearch::AddLineSegment`, which had a bug caused by floating number arithmetic, and would miss segments nearly parallel to grid lines.

@kevinkreiser would be great to give it a review before merge.