### PR TITLE
Improve interpolation

### DIFF
--- a/src/meili/map_matcher.cc
+++ b/src/meili/map_matcher.cc
@@ -98,7 +98,6 @@ InterpolateMeasurement(const MapMatching& mapmatching,
     segment_begin_route_distance += directededge->length() * (segment->target - segment->source);
   }
 
-  // {interpolated_at_point, interpolated_at_edgeid, std::sqrt(interpolated_sq_distance), interpolated_route_distance};
   return best_interp;
 }
 
@@ -254,8 +253,8 @@ FindMatchResult(const MapMatching::state_iterator& previous_state,
     }
   }
 
-  // Although we failed to infer the route and the edge, at least we
-  // know which point it matches
+  // If we failed to infer the route and the edge, at least we know
+  // which point it matches
   const auto& c = state.candidate();
   //Note: technically a candidate can have correlated to more than one place in the graph
   //but the way its used in meili we only correlated it to one place so .front() is safe
@@ -344,7 +343,6 @@ MapMatcher::~MapMatcher() {}
 std::vector<MatchResult>
 MapMatcher::OfflineMatch(const std::vector<Measurement>& measurements)
 {
-  // Clear all previous measurements and states TODO: should we do it?
   mapmatching_.Clear();
 
   const auto begin = measurements.begin(),

--- a/src/meili/map_matcher.cc
+++ b/src/meili/map_matcher.cc
@@ -146,14 +146,6 @@ InterpolateMeasurements(const MapMatching& mapmatching,
     const auto& match_measurement = mapmatching.measurement(state->time());
     const auto match_measurement_distance = GreatCircleDistance(measurement, match_measurement);
 
-    const auto& up_interp = InterpolateMeasurement(
-        mapmatching,
-        upstream_route.rbegin(),
-        upstream_route.rend(),
-        measurement,
-        match_measurement_distance,
-        true);
-
     const auto& down_interp = InterpolateMeasurement(
         mapmatching,
         downstream_route.begin(),
@@ -162,21 +154,15 @@ InterpolateMeasurements(const MapMatching& mapmatching,
         match_measurement_distance,
         false);
 
-    if (up_interp.edgeid.Is_Valid() && down_interp.edgeid.Is_Valid()) {
-      const auto down_cost = down_interp.sortcost(mapmatching, match_measurement_distance),
-                   up_cost = up_interp.sortcost(mapmatching, match_measurement_distance);
-      if (down_cost < up_cost) {
-        results.emplace_back(down_interp.projected, std::sqrt(down_interp.sq_distance), down_interp.edgeid);
-      } else {
-        results.emplace_back(up_interp.projected, std::sqrt(up_interp.sq_distance), up_interp.edgeid);
-      }
-
-    } else if (up_interp.edgeid.Is_Valid()) {
-      results.emplace_back(up_interp.projected, std::sqrt(up_interp.sq_distance), up_interp.edgeid);
-
-    } else if (down_interp.edgeid.Is_Valid()) {
-      results.emplace_back(down_interp.projected, std::sqrt(down_interp.sq_distance), down_interp.edgeid);
-
+    if (down_interp.edgeid.Is_Valid()) {
+      results.emplace_back(down_interp.projected,
+                           std::sqrt(down_interp.sq_distance),
+                           down_interp.edgeid);
+    } else if (!upstream_route.empty()) {
+      // Match the end point of the upstream route
+      results.emplace_back(state->candidate().edges.front().projected,
+                           state->candidate().distance(),
+                           upstream_route.back().edgeid);
     } else {
       results.emplace_back(measurement.lnglat());
     }

--- a/src/meili/map_matcher.cc
+++ b/src/meili/map_matcher.cc
@@ -55,7 +55,8 @@ InterpolateMeasurement(const MapMatching& mapmatching,
   float segment_begin_route_distance = 0.f;
   float minimal_cost = std::numeric_limits<float>::infinity();
 
-  Interpolation best_interp;
+  // Invalid edgeid indicates that no interpolation found
+  Interpolation best_interp{{}, {}, 0.f, 0.f};
 
   for (auto segment = begin; segment != end; segment++) {
     const auto directededge = helpers::edge_directededge(mapmatching.graphreader(), segment->edgeid, tile);

--- a/src/meili/map_matcher.cc
+++ b/src/meili/map_matcher.cc
@@ -1,6 +1,10 @@
-#include <vector>
+#include <valhalla/midgard/distanceapproximator.h>
 
 #include "meili/graph_helpers.h"
+#include "meili/routing.h"
+#include "meili/geometry_helpers.h"
+#include "meili/graph_helpers.h"
+#include "meili/match_route.h"
 #include "meili/map_matcher.h"
 
 
@@ -16,264 +20,322 @@ GreatCircleDistanceSquared(const Measurement& left,
 { return left.lnglat().DistanceSquared(right.lnglat()); }
 
 
-// Collect a nodeid set of a path location
-std::unordered_set<baldr::GraphId>
-collect_nodes(baldr::GraphReader& graphreader, const Candidate& location)
-{
-  std::unordered_set<baldr::GraphId> results;
-  const baldr::GraphTile* tile = nullptr;
+inline float
+GreatCircleDistance(const Measurement& left,
+                    const Measurement& right)
+{ return left.lnglat().Distance(right.lnglat()); }
 
-  for (const auto& edge : location.edges) {
-    if (!edge.id.Is_Valid()) continue;
-    if (edge.dist == 0.f) {
-      const auto& startnodeid = helpers::edge_startnodeid(graphreader, edge.id, tile);
-      if (startnodeid.Is_Valid()) {
-        results.insert(startnodeid);
-      }
-    } else if (edge.dist == 1.f) {
-      const auto& endnodeid = helpers::edge_endnodeid(graphreader, edge.id, tile);
-      if (endnodeid.Is_Valid()) {
-        results.insert(endnodeid);
-      }
+
+// Find the projected point along the route where the route distance
+// of this point to the beginning of the route is closest to the match
+// measurement distance.
+
+// Return the projected point, projected edgeid, squared distance to
+// the projected point, and the route distance of the projected
+// point. If nothing found the invalid edgeid will return
+template <typename segment_iterator_t>
+std::tuple<midgard::PointLL, baldr::GraphId, float, float>
+InterpolateMeasurement(const MapMatching& mapmatching,
+                       segment_iterator_t begin,
+                       segment_iterator_t end,
+                       const Measurement& measurement,
+                       float match_measurement_distance,
+                       bool reverse)
+{
+  const baldr::GraphTile* tile(nullptr);
+  midgard::DistanceApproximator approximator(measurement.lnglat());
+
+  // Route distance from each segment begin to the beginning segment
+  float segment_begin_route_distance = 0.f;
+  float minimal_delta = std::numeric_limits<float>::infinity();
+
+  midgard::PointLL interpolated_at_point;
+  baldr::GraphId interpolated_at_edgeid;
+  float interpolated_sq_distance = 0.f,
+     interpolated_route_distance = 0.f;
+
+  for (auto segment = begin; segment != end; segment++) {
+    const auto directededge = helpers::edge_directededge(mapmatching.graphreader(), segment->edgeid, tile);
+    if (!directededge) {
+      continue;
     }
+
+    const auto edgeinfo = tile->edgeinfo(directededge->edgeinfo_offset());
+
+    const auto& shape = edgeinfo->shape();
+    if (shape.empty()) {
+      continue;
+    }
+
+    midgard::PointLL projected_point;
+    float sq_distance, offset;
+    std::tie(projected_point, sq_distance, std::ignore, offset) = helpers::Project(measurement.lnglat(), shape, approximator);
+
+    // Find out the correct offset
+    if (!directededge->forward()) {
+      offset = 1.f - offset;
+    }
+
+    // Distance from the projected point to the segment begin, or
+    // segment begin if we walk reversely
+    const auto distance_to_segment_ends = std::abs(directededge->length() * (reverse? (segment->target - offset) : (offset - segment->source)));
+
+    // The absolute route distance from projected point to the
+    // beginning segment
+    const auto route_distance = segment_begin_route_distance + distance_to_segment_ends;
+
+    const auto delta = std::abs(route_distance - match_measurement_distance);
+    if (delta < minimal_delta) {
+      minimal_delta = delta;
+      interpolated_at_point = projected_point;
+      interpolated_at_edgeid = segment->edgeid;
+      interpolated_sq_distance = sq_distance;
+      interpolated_route_distance = route_distance;
+    }
+
+    // Since route_distance is increasing, the delta at next iteration
+    // (next_route_distance - match_measurement_distance) must be
+    // larger than this delta (route_distance -
+    // match_measurement_distance), so the next delta is impossible to
+    // be the minimal delta, hence the break
+    if (match_measurement_distance < route_distance) {
+      break;
+    }
+
+    // Assume segments are connected
+    segment_begin_route_distance += directededge->length() * (segment->target - segment->source);
   }
 
-  return results;
+  return {interpolated_at_point, interpolated_at_edgeid, std::sqrt(interpolated_sq_distance), interpolated_route_distance};
 }
 
 
-MatchResult
-guess_source_result(const MapMatching::state_iterator source,
-                    const MapMatching::state_iterator target,
-                    const Measurement& source_measurement)
-{
-  if (source.IsValid() && target.IsValid()) {
-    baldr::GraphId last_valid_id;
-    GraphType last_valid_type = GraphType::kUnknown;
-    for (auto label = source->RouteBegin(*target);
-         label != source->RouteEnd(); label++) {
-      if (label->nodeid.Is_Valid()) {
-        last_valid_id = label->nodeid;
-        last_valid_type = GraphType::kNode;
-      } else if (label->edgeid.Is_Valid()) {
-        last_valid_id = label->edgeid;
-        last_valid_type = GraphType::kEdge;
-      }
-    }
-    const auto& c = source->candidate();
-    //Note: technically a candidate can have correlated to more than one place in the graph
-    //but the way its used in meili we only correlated it to one place so .front() is safe
-    return {c.edges.front().projected, c.distance(), last_valid_id, last_valid_type, source->id()};
-  } else if (source.IsValid()) {
-    return {source_measurement.lnglat(), 0.f, baldr::GraphId(), GraphType::kUnknown, source->id()};
-  }
-
-  return {source_measurement.lnglat()};
-}
-
-
-MatchResult
-guess_target_result(const MapMatching::state_iterator source,
-                    const MapMatching::state_iterator target,
-                    const Measurement& target_measurement)
-{
-  if (source.IsValid() && target.IsValid()) {
-    auto label = source->RouteBegin(*target);
-    baldr::GraphId graphid;
-    GraphType graphtype = GraphType::kUnknown;
-    if (label != source->RouteEnd()) {
-      if (label->nodeid.Is_Valid()) {
-        graphid = label->nodeid;
-        graphtype = GraphType::kNode;
-      } else if (label->edgeid.Is_Valid()) {
-        graphid = label->edgeid;
-        graphtype = GraphType::kEdge;
-      }
-    }
-    const auto& c = target->candidate();
-    //Note: technically a candidate can have correlated to more than one place in the graph
-    //but the way its used in meili we only correlated it to one place so .front() is safe
-    return {c.edges.front().projected, c.distance(), graphid, graphtype, target->id()};
-  } else if (target.IsValid()) {
-    return {target_measurement.lnglat(), 0.f, baldr::GraphId(), GraphType::kUnknown, target->id()};
-  }
-
-  return {target_measurement.lnglat()};
-}
-
-
-template <typename candidate_iterator_t>
-MatchResult
-interpolate(baldr::GraphReader& reader,
-            const std::unordered_set<baldr::GraphId>& graphset,
-            candidate_iterator_t begin,
-            candidate_iterator_t end,
-            const Measurement& measurement)
-{
-  auto closest_candidate = end;
-  float closest_sq_distance = std::numeric_limits<float>::infinity();
-  baldr::GraphId closest_graphid;
-  GraphType closest_graphtype = GraphType::kUnknown;
-
-  for (auto candidate = begin; candidate != end; candidate++) {
-    if (candidate->sq_distance() < closest_sq_distance) {
-      //Note: technically a candidate can have correlated to more than one place in the graph
-      //but the way its used in meili we only correlated it to one place so .front() is safe
-      if (!candidate->edges.front().begin_node() && !candidate->edges.front().end_node()) {
-        for (const auto& edge : candidate->edges) {
-          const auto it = graphset.find(edge.id);
-          if (it != graphset.end()) {
-            closest_candidate = candidate;
-            closest_sq_distance = candidate->sq_distance();
-            closest_graphid = edge.id;
-            closest_graphtype = GraphType::kEdge;
-          }
-        }
-      } else {
-        for (const auto nodeid : collect_nodes(reader, *candidate)) {
-          const auto it = graphset.find(nodeid);
-          if (it != graphset.end()) {
-            closest_candidate = candidate;
-            closest_sq_distance = candidate->sq_distance();
-            closest_graphid = nodeid;
-            closest_graphtype = GraphType::kNode;
-          }
-        }
-      }
-    }
-  }
-
-  if (closest_candidate != end) {
-    //Note: technically a candidate can have correlated to more than one place in the graph
-    //but the way its used in meili we only correlated it to one place so .front() is safe
-    return {closest_candidate->edges.front().projected, closest_candidate->distance(), closest_graphid, closest_graphtype, kInvalidStateId};
-  }
-
-  return {measurement.lnglat()};
-}
-
-
-std::unordered_set<baldr::GraphId>
-collect_graphset(baldr::GraphReader& reader,
-                 const MapMatching::state_iterator source,
-                 const MapMatching::state_iterator target)
-{
-  std::unordered_set<baldr::GraphId> graphset;
-  if (source.IsValid() && target.IsValid()) {
-    for (auto label = source->RouteBegin(*target);
-         label != source->RouteEnd();
-         ++label) {
-      if (label->edgeid.Is_Valid()) {
-        graphset.insert(label->edgeid);
-      }
-      if (label->nodeid.Is_Valid()) {
-        graphset.insert(label->nodeid);
-      }
-    }
-  } else if (source.IsValid()) {
-    const auto& location = source->candidate();
-    //Note: technically a location can have correlated to more than one place in the graph
-    //but the way its used in meili we only correlated it to one place so .front() is safe
-    if (!location.edges.front().begin_node() && !location.edges.front().end_node()) {
-      for (const auto& edge : location.edges) {
-        if (edge.id.Is_Valid()) {
-          graphset.insert(edge.id);
-        }
-      }
-    } else {
-      for (const auto nodeid : collect_nodes(reader, location)) {
-        if (nodeid.Is_Valid()) {
-          graphset.insert(nodeid);
-        }
-      }
-    }
-  }
-
-  return graphset;
-}
-
-
+// Iterpolate measurements along the route from prevous state to
+// current state, or along the route from current state to next state
 std::vector<MatchResult>
-OfflineMatch_(MapMatching& mm,
-              const CandidateQuery& cq,
-              const std::vector<Measurement>& measurements,
-              float interpolation_distance)
+InterpolateMeasurements(const MapMatching& mapmatching,
+                        const MapMatching::state_iterator& previous_state,
+                        const MapMatching::state_iterator& state,
+                        const MapMatching::state_iterator& next_state,
+                        const std::vector<Measurement>& interpolated_measurements)
 {
-  mm.Clear();
-
-  if (measurements.empty()) {
+  if (interpolated_measurements.empty()) {
     return {};
   }
 
-  using mmt_size_t = std::vector<Measurement>::size_type;
-  Time time = 0;
-  const float sq_interpolation_distance = interpolation_distance * interpolation_distance;
-  std::unordered_map<Time, std::vector<mmt_size_t>> proximate_measurements;
-
-  // Load states
-  for (mmt_size_t idx = 0,
-             last_idx = 0,
-              end_idx = measurements.size() - 1;
-       idx <= end_idx; idx++) {
-    const auto& measurement = measurements[idx];
-    auto sq_distance = GreatCircleDistanceSquared(measurements[last_idx], measurement);
-    // Always match the first and the last measurement
-    if (sq_interpolation_distance <= sq_distance || idx == 0 || idx == end_idx) {
-      const auto& candidates = cq.Query(measurement.lnglat(),
-                                        measurement.sq_search_radius(),
-                                        mm.costing()->GetEdgeFilter());
-      time = mm.AppendState(measurement, candidates.begin(), candidates.end());
-      last_idx = idx;
-    } else {
-      proximate_measurements[time].push_back(idx);
-    }
-  }
-
-  // Search viterbi path
-  std::vector<MapMatching::state_iterator> iterpath;
-  iterpath.reserve(mm.size());
-  for (auto it = mm.SearchPath(time); it != mm.PathEnd(); it++) {
-    iterpath.push_back(it);
-  }
-  std::reverse(iterpath.begin(), iterpath.end());
-  if (!(iterpath.size() == mm.size())) {
-    std::logic_error("Every measurement should have matched a state");
-  }
-
-  // Interpolate proximate measurements and merge their states into
-  // the results
   std::vector<MatchResult> results;
-  results.reserve(measurements.size());
-  results.emplace_back(measurements.front().lnglat());
 
-  for (Time time = 1; time < mm.size(); time++) {
-    const auto &source_state = iterpath[time - 1],
-               &target_state = iterpath[time];
-
-    if (!results.back().graphid().Is_Valid()) {
-      results.pop_back();
-      results.push_back(guess_source_result(source_state, target_state, measurements[results.size()]));
+  if (!state.IsValid()) {
+    for (const auto& measurement: interpolated_measurements) {
+      results.emplace_back(measurement.lnglat());
     }
+    return results;
+  }
 
-    auto it = proximate_measurements.find(time - 1);
-    if (it != proximate_measurements.end()) {
-      const auto& graphset = collect_graphset(mm.graphreader(), source_state, target_state);
-      for (const auto idx : it->second) {
-        const auto& candidates = cq.Query(measurements[idx].lnglat(),
-                                          measurements[idx].sq_search_radius(),
-                                          mm.costing()->GetEdgeFilter());
-        results.push_back(interpolate(mm.graphreader(), graphset,
-                                      candidates.begin(), candidates.end(),
-                                      measurements[idx]));
+  std::vector<EdgeSegment> upstream_route;
+  if (previous_state.IsValid()) {
+    MergeRoute(upstream_route, *previous_state, *state);
+  }
+
+  std::vector<EdgeSegment> downstream_route;
+  if (next_state.IsValid()) {
+    MergeRoute(downstream_route, *state, *next_state);
+  }
+
+  if (upstream_route.empty() && downstream_route.empty()) {
+    for (const auto& measurement: interpolated_measurements) {
+      results.emplace_back(measurement.lnglat());
+    }
+    return results;
+  }
+
+  for (const auto& measurement: interpolated_measurements) {
+    const auto& match_measurement = mapmatching.measurement(state->time());
+    const auto match_measurement_distance = GreatCircleDistance(measurement, match_measurement);
+
+    const auto& upstream_interpolation = InterpolateMeasurement(
+        mapmatching,
+        upstream_route.rbegin(),
+        upstream_route.rend(),
+        measurement,
+        match_measurement_distance,
+        true);
+
+    const auto& downstream_interpolation = InterpolateMeasurement(
+        mapmatching,
+        downstream_route.begin(),
+        downstream_route.end(),
+        measurement,
+        match_measurement_distance,
+        false);
+
+    const auto &upstream_edge = std::get<1>(upstream_interpolation),
+             &downstream_edge = std::get<1>(downstream_interpolation);
+
+    if (upstream_edge.Is_Valid() && downstream_edge.Is_Valid()) {
+      const auto upstream_delta = std::abs(std::get<3>(upstream_interpolation) - match_measurement_distance),
+               downstream_delta = std::abs(std::get<3>(downstream_interpolation) - match_measurement_distance);
+
+      if (downstream_delta < upstream_delta) {
+        results.emplace_back(std::get<0>(downstream_interpolation),
+                             std::get<2>(downstream_interpolation),
+                             downstream_edge);
+      } else {
+        results.emplace_back(std::get<0>(upstream_interpolation),
+                             std::get<2>(upstream_interpolation),
+                             upstream_edge);
+      }
+
+    } else if (upstream_edge.Is_Valid()) {
+      results.emplace_back(std::get<0>(upstream_interpolation),
+                           std::get<2>(upstream_interpolation),
+                           upstream_edge);
+
+    } else if (downstream_edge.Is_Valid()) {
+      results.emplace_back(std::get<0>(downstream_interpolation),
+                           std::get<2>(downstream_interpolation),
+                           downstream_edge);
+
+    } else {
+      results.emplace_back(measurement.lnglat());
+    }
+  }
+
+  return results;
+}
+
+
+// Interplolate measurements grouped by previous match measurement
+// time
+std::unordered_map<Time, std::vector<MatchResult>>
+InterpolateTimedMeasurements(const MapMatching& mapmatching,
+                             const MapMatching::state_iterator& state_rbegin,
+                             const MapMatching::state_iterator& state_rend,
+                             const std::unordered_map<Time, std::vector<Measurement>>& interpolated_measurements,
+                             Time time)
+{
+  std::unordered_map<Time, std::vector<MatchResult>> resultmap;
+
+  for (auto previous_state = std::next(state_rbegin),
+                     state = state_rbegin,
+                next_state = MapMatching::state_iterator(nullptr);
+       state != state_rend;
+       next_state = state, state++, previous_state = std::next(state)) {
+
+    const auto it = interpolated_measurements.find(time);
+    if (it != interpolated_measurements.end()) {
+      if (state.IsValid()) {
+        const auto& results = InterpolateMeasurements(mapmatching, previous_state, state, next_state, it->second);
+        resultmap.emplace(time, results);
+      } else {
+        auto& results = resultmap[time];
+        for (const auto& measurement: it->second) {
+          results.push_back(MatchResult(measurement.lnglat()));
+        }
       }
     }
 
-    results.push_back(guess_target_result(source_state, target_state, measurements[results.size()]));
+    time--;
   }
-  if(results.size() != measurements.size())
-    throw std::logic_error("The number of matched points does not match the number of input points.");
 
+  return resultmap;
+}
+
+
+// Find the match result of a state, given its previous state and next
+// state
+MatchResult
+FindMatchResult(const MapMatching::state_iterator& previous_state,
+                const State& state,
+                const MapMatching::state_iterator& next_state)
+{
+  baldr::GraphId edgeid;
+
+  // Construct the route from previous state to current state, and
+  // find out which edge it matches
+  if (previous_state.IsValid()) {
+    // It must stay on the last edge of the route
+    const auto rbegin = previous_state->RouteBegin(state),
+                 rend = previous_state->RouteEnd();
+    if (rbegin != rend) {
+      edgeid = rbegin->edgeid;
+    }
+  }
+
+  // Do the same from current state to next state
+  if (!edgeid.Is_Valid() && next_state.IsValid()) {
+    // It must stay on the first edge of the route
+    for (auto label = state.RouteBegin(*next_state);
+         label != state.RouteEnd(); label++) {
+      if (label->edgeid.Is_Valid()) {
+        edgeid = label->edgeid;
+      }
+    }
+  }
+
+  // Although we failed to infer the route and the edge, at least we
+  // know which point it matches
+  const auto& c = state.candidate();
+  //Note: technically a candidate can have correlated to more than one place in the graph
+  //but the way its used in meili we only correlated it to one place so .front() is safe
+  return {c.edges.front().projected, c.distance(), edgeid, state.id()};
+}
+
+
+// Find the corresponding match results of a list of states
+std::vector<MatchResult>
+FindMatchResults(const MapMatching& mapmatching,
+                 const MapMatching::state_iterator& state_rbegin,
+                 const MapMatching::state_iterator& state_rend,
+                 Time time)
+{
+  if (state_rbegin == state_rend) {
+    return {};
+  }
+
+  std::vector<MatchResult> results;
+
+  for (auto previous_state = std::next(state_rbegin),
+                     state = state_rbegin,
+                next_state = MapMatching::state_iterator(nullptr);
+       state != state_rend;
+       next_state = state, state++, previous_state = std::next(state)) {
+    if (state.IsValid()) {
+      results.push_back(FindMatchResult(previous_state, *state, next_state));
+    } else {
+      results.emplace_back(mapmatching.measurement(time).lnglat());
+    }
+    time--;
+  }
+
+  std::reverse(results.begin(), results.end());
   return results;
+}
+
+
+// Insert the interpolated results into the result list, and
+// return a new result list
+std::vector<MatchResult>
+MergeMatchResults(const std::vector<MatchResult>& results,
+                  const std::unordered_map<Time, std::vector<MatchResult>>& interpolated_results)
+{
+  std::vector<MatchResult> merged_results;
+
+  Time time = 0;
+  for (const auto& result: results) {
+    merged_results.push_back(result);
+
+    const auto it = interpolated_results.find(time);
+    if (it != interpolated_results.end()) {
+      for (const auto& result: it->second) {
+        merged_results.push_back(result);
+      }
+    }
+
+    time++;
+  }
+
+  return merged_results;
 }
 
 }
@@ -301,8 +363,67 @@ MapMatcher::~MapMatcher() {}
 std::vector<MatchResult>
 MapMatcher::OfflineMatch(const std::vector<Measurement>& measurements)
 {
-  const auto interpolation_distance = config_.get<float>("interpolation_distance");
-  return OfflineMatch_(mapmatching_, candidatequery_, measurements, interpolation_distance);
+  // Clear all previous measurements and states TODO: should we do it?
+  mapmatching_.Clear();
+
+  const auto begin = measurements.begin(),
+               end = measurements.end();
+
+  if (begin == end) {
+    return {};
+  }
+
+  const auto interpolation_distance = config_.get<float>("interpolation_distance"),
+          sq_interpolation_distance = interpolation_distance * interpolation_distance;
+  std::unordered_map<Time, std::vector<Measurement>> interpolated_measurements;
+
+  // Always match the first measurement
+  auto time = AppendMeasurement(*begin);
+  auto latest_match_measurement = begin;
+  std::size_t match_count = 1;
+
+  for (auto measurement = next(begin); measurement != end; measurement++) {
+    const auto sq_distance = GreatCircleDistanceSquared(*latest_match_measurement, *measurement);
+    // Always match the last measurement
+    if (sq_interpolation_distance < sq_distance || std::next(measurement) == end) {
+      time = AppendMeasurement(*measurement);
+      latest_match_measurement = measurement;
+      match_count++;
+    } else {
+      interpolated_measurements[time].push_back(*measurement);
+    }
+  }
+
+  const auto state_rbegin = mapmatching_.SearchPath(time),
+               state_rend = std::next(state_rbegin, match_count);
+  const auto& results = FindMatchResults(mapmatching_, state_rbegin, state_rend, time);
+
+  // Done if no measurements to interpolate
+  if (interpolated_measurements.empty()) {
+    return results;
+  }
+
+  // Find results for all interpolated measurements
+  const auto& interpolated_results = InterpolateTimedMeasurements(
+      mapmatching_,
+      state_rbegin,
+      state_rend,
+      interpolated_measurements,
+      time);
+
+  // Insert the interpolated results into the result list
+  return MergeMatchResults(results, interpolated_results);
+}
+
+
+Time
+MapMatcher::AppendMeasurement(const Measurement& measurement)
+{
+  const auto& candidates = candidatequery_.Query(
+      measurement.lnglat(),
+      measurement.sq_search_radius(),
+      mapmatching_.costing()->GetEdgeFilter());
+  return mapmatching_.AppendState(measurement, candidates.begin(), candidates.end());
 }
 
 }

--- a/src/meili/map_matching.cc
+++ b/src/meili/map_matching.cc
@@ -30,6 +30,7 @@ State::State(const StateId id, const Time time, const Candidate& candidate)
       labelset_(nullptr),
       label_idx_() {}
 
+
 void
 State::route(const std::vector<const State*>& states,
              baldr::GraphReader& graphreader,
@@ -194,7 +195,7 @@ MapMatching::TransitionCost(const State& left, const State& right) const
   const auto label = left.last_label(right);
   if (label) {
     const auto mmt_distance = GreatCircleDistance(measurement(left), measurement(right));
-    return (label->turn_cost + std::abs(label->cost - mmt_distance)) * inv_beta_;
+    return CalculateTransitionCost(label->turn_cost, label->cost, mmt_distance);
   }
 
   return -1.f;
@@ -203,7 +204,7 @@ MapMatching::TransitionCost(const State& left, const State& right) const
 
 inline float
 MapMatching::EmissionCost(const State& state) const
-{ return state.candidate().sq_distance() * inv_double_sq_sigma_z_; }
+{ return CalculateEmissionCost(state.candidate().sq_distance()); }
 
 
 inline double

--- a/src/meili/match_route.cc
+++ b/src/meili/match_route.cc
@@ -208,6 +208,10 @@ EdgeSegment::EdgeSegment(baldr::GraphId the_edgeid,
       source(the_source),
       target(the_target)
 {
+  if (!edgeid.Is_Valid()) {
+    throw std::invalid_argument("Invalid edgeid");
+  }
+
   if (!(0.f <= source && source <= target && target <= 1.f)) {
     throw std::invalid_argument("Expect 0.f <= source <= target <= 1.f, but you got source = "
                                 + std::to_string(source)
@@ -238,11 +242,6 @@ EdgeSegment::Shape(baldr::GraphReader& graphreader) const
 
 bool EdgeSegment::Adjoined(baldr::GraphReader& graphreader, const EdgeSegment& other) const
 {
-  // Skip dummy segments
-  if (!edgeid.Is_Valid() || !other.edgeid.Is_Valid()) {
-    return false;
-  }
-
   if (edgeid != other.edgeid) {
     if (target == 1.f && other.source == 0.f) {
       const auto endnode = helpers::edge_endnodeid(graphreader, edgeid);

--- a/src/meili/match_route.cc
+++ b/src/meili/match_route.cc
@@ -220,14 +220,26 @@ bool EdgeSegment::Adjoined(baldr::GraphReader& graphreader, const EdgeSegment& o
 
 
 std::vector<EdgeSegment>&
-MergeRoute(std::vector<EdgeSegment>& route,
-           const RoutePathIterator& route_begin,
-           const RoutePathIterator& route_end)
+MergeRoute(std::vector<EdgeSegment>& route, const State& source, const State& target)
 {
+  const auto route_rbegin = source.RouteBegin(target),
+               route_rend = source.RouteEnd();
+
+  if (route_rbegin == route_rend) {
+    return route;
+  }
+
   std::vector<EdgeSegment> segments;
 
-  for (auto label = route_begin; label != route_end; label++) {
+  auto label = route_rbegin;
+
+  // Skip the first dummy edge std::prev(route_rend)
+  for (; std::next(label) != route_rend; label++) {
     segments.emplace_back(label->edgeid, label->source, label->target);
+  }
+
+  if (label->edgeid.Is_Valid()) {
+    throw std::logic_error("The first edge must be dummy");
   }
 
   return MergeEdgeSegments(route, segments.rbegin(), segments.rend());
@@ -235,11 +247,10 @@ MergeRoute(std::vector<EdgeSegment>& route,
 
 
 std::vector<EdgeSegment>
-MergeRoute(const RoutePathIterator& route_begin,
-           const RoutePathIterator& route_end)
+MergeRoute(const State& source, const State& target)
 {
-  std::vector<EdgeSegment> segments;
-  return MergeRoute(segments, route_begin, route_end);
+  std::vector<EdgeSegment> route;
+  return MergeRoute(route, source, target);
 }
 
 

--- a/src/meili/match_route.cc
+++ b/src/meili/match_route.cc
@@ -163,27 +163,12 @@ MergeEdgeSegments(std::vector<EdgeSegment>& route,
     return route;
   }
 
-  for (auto segment = std::next(segment_begin);  // Skip the first dummy segment
-       segment != segment_end; segment++) {
-    if (!segment->edgeid.Is_Valid()) {
-      throw std::runtime_error("Still found an invalid edgeid in route segments");
-    }
+  for (auto segment = segment_begin; segment != segment_end; segment++) {
     if(!route.empty()) {
       auto& last_segment = route.back();
-      if (last_segment.edgeid == segment->edgeid) {
-        if (last_segment.target != segment->source
-            && segment != std::next(segment_begin)) {
-          // TODO should throw runtime error. See the temporary fix
-          LOG_ERROR("Still found a disconnected route in which segment "
-                    + std::to_string(segment - segment_begin) + " ends at "
-                    + std::to_string(last_segment.target)
-                    + " but the next segment starts at "
-                    + std::to_string(segment->source));
-        }
-        // and here we should extend last_segment.target =
-        // segment->target since last_segment.target <=
-        // segment->target but see the temporary fix
-        last_segment.target = std::max(last_segment.target, segment->target);
+      if (last_segment.edgeid == segment->edgeid && last_segment.target == segment->source) {
+        // Extend last segment
+        last_segment.target = segment->target;
       } else {
         route.push_back(*segment);
       }

--- a/valhalla/meili/geojson_writer.h
+++ b/valhalla/meili/geojson_writer.h
@@ -169,7 +169,7 @@ void serialize_verbose(rapidjson::Writer<buffer_t>& writer,
   writer.String("graphids");
   writer.StartArray();
   for (const auto& result : results) {
-    writer.Uint64(result.graphid().id());
+    writer.Uint64(result.edgeid().id());
   }
   writer.EndArray();
 
@@ -387,7 +387,7 @@ void GeoJSONRouteWriter<buffer_t>::WriteProperties(rapidjson::Writer<buffer_t>& 
   writer.String("matched_coordinates");
   writer.StartArray();
   for (const auto& result : results) {
-    if (result.graphid().Is_Valid()) {
+    if (result.edgeid().Is_Valid()) {
       serialize_coordinate(writer, result.lnglat());
     } else {
       writer.Null();

--- a/valhalla/meili/geojson_writer.h
+++ b/valhalla/meili/geojson_writer.h
@@ -368,8 +368,7 @@ void GeoJSONRouteWriter<buffer_t>::WriteGeometry(rapidjson::Writer<buffer_t>& wr
 
   writer.String("coordinates");
   writer.StartArray();
-  const auto& segments = ConstructRoute(mapmatcher.graphreader(),
-                                        mapmatcher,
+  const auto& segments = ConstructRoute(mapmatcher.mapmatching(),
                                         results.cbegin(),
                                         results.cend());
   WriteRoute(writer, mapmatcher, segments);

--- a/valhalla/meili/map_matcher.h
+++ b/valhalla/meili/map_matcher.h
@@ -48,6 +48,8 @@ public:
   OfflineMatch(const std::vector<Measurement>& measurements);
 
 private:
+  Time AppendMeasurement(const Measurement& measurement);
+
   boost::property_tree::ptree config_;
 
   baldr::GraphReader& graphreader_;

--- a/valhalla/meili/map_matching.h
+++ b/valhalla/meili/map_matching.h
@@ -13,6 +13,7 @@
 namespace valhalla{
 namespace meili {
 
+
 class State
 {
  public:
@@ -127,6 +128,14 @@ class MapMatching: public ViterbiSearch<State>
 
     return time;
   }
+
+  float
+  CalculateEmissionCost(float sq_distance) const
+  { return sq_distance * inv_double_sq_sigma_z_; }
+
+  float
+  CalculateTransitionCost(float turncost, float route_distance, float measurement_distance) const
+  { return (turncost + std::abs(route_distance - measurement_distance)) * inv_beta_; }
 
  protected:
   virtual float MaxRouteDistance(const State& left, const State& right) const;

--- a/valhalla/meili/match_result.h
+++ b/valhalla/meili/match_result.h
@@ -17,32 +17,27 @@ class MatchResult
   MatchResult(const midgard::PointLL& lnglat,
               float distance,
               const baldr::GraphId edgeid,
-              StateId stateid)
+              StateId stateid = kInvalidStateId)
       : lnglat_(lnglat),
         distance_(distance),
         edgeid_(edgeid),
         stateid_(stateid) {}
 
   MatchResult(const midgard::PointLL& lnglat)
-      : lnglat_(lnglat),
-        distance_(0.f),
-        edgeid_(),
-        stateid_(kInvalidStateId) {}
+      : MatchResult(lnglat, 0.f, {}, kInvalidStateId) {}
 
-  // Coordinate of the matched point
+  // Coordinate of the match point
   const midgard::PointLL& lnglat() const
   { return lnglat_; }
 
-  // Distance from measurement to the matched point
+  // Distance from measurement to the match point
   float distance() const
   { return distance_; }
 
-  // Which edge/node this matched point stays
+  // Which edge this match point stays
   const baldr::GraphId& edgeid() const
   { return edgeid_; }
 
-  // Attach the state pointer for other information (e.g. reconstruct
-  // the route path) and debugging
   StateId stateid() const
   { return stateid_; }
 

--- a/valhalla/meili/match_result.h
+++ b/valhalla/meili/match_result.h
@@ -11,29 +11,22 @@
 namespace valhalla {
 namespace meili {
 
-enum class GraphType: uint8_t
-{ kUnknown = 0, kEdge, kNode };
-
-
 class MatchResult
 {
  public:
   MatchResult(const midgard::PointLL& lnglat,
               float distance,
-              const baldr::GraphId graphid,
-              GraphType graphtype,
+              const baldr::GraphId edgeid,
               StateId stateid)
       : lnglat_(lnglat),
         distance_(distance),
-        graphid_(graphid),
-        graphtype_(graphtype),
+        edgeid_(edgeid),
         stateid_(stateid) {}
 
   MatchResult(const midgard::PointLL& lnglat)
       : lnglat_(lnglat),
         distance_(0.f),
-        graphid_(),
-        graphtype_(GraphType::kUnknown),
+        edgeid_(),
         stateid_(kInvalidStateId) {}
 
   // Coordinate of the matched point
@@ -45,11 +38,8 @@ class MatchResult
   { return distance_; }
 
   // Which edge/node this matched point stays
-  const baldr::GraphId graphid() const
-  { return graphid_; }
-
-  GraphType graphtype() const
-  { return graphtype_; }
+  const baldr::GraphId& edgeid() const
+  { return edgeid_; }
 
   // Attach the state pointer for other information (e.g. reconstruct
   // the route path) and debugging
@@ -64,9 +54,7 @@ class MatchResult
 
   float distance_;
 
-  baldr::GraphId graphid_;
-
-  GraphType graphtype_;
+  baldr::GraphId edgeid_;
 
   StateId stateid_;
 };

--- a/valhalla/meili/match_route.h
+++ b/valhalla/meili/match_route.h
@@ -37,14 +37,11 @@ struct EdgeSegment
 
 
 std::vector<EdgeSegment>&
-MergeRoute(std::vector<EdgeSegment>& route,
-           const RoutePathIterator& route_begin,
-           const RoutePathIterator& route_end);
+MergeRoute(std::vector<EdgeSegment>& route, const State& source, const State& target);
 
 
 std::vector<EdgeSegment>
-MergeRoute(const RoutePathIterator& route_begin,
-           const RoutePathIterator& route_end);
+MergeRoute(const State& source, const State& target);
 
 
 template <typename match_iterator_t>

--- a/valhalla/meili/match_route.h
+++ b/valhalla/meili/match_route.h
@@ -8,7 +8,8 @@
 #include <valhalla/baldr/graphreader.h>
 #include <valhalla/baldr/graphid.h>
 
-#include <valhalla/meili/map_matcher.h>
+#include <valhalla/meili/routing.h>
+#include <valhalla/meili/map_matching.h>
 
 
 namespace valhalla {
@@ -35,10 +36,20 @@ struct EdgeSegment
 };
 
 
+std::vector<EdgeSegment>&
+MergeRoute(std::vector<EdgeSegment>& route,
+           const RoutePathIterator& route_begin,
+           const RoutePathIterator& route_end);
+
+
+std::vector<EdgeSegment>
+MergeRoute(const RoutePathIterator& route_begin,
+           const RoutePathIterator& route_end);
+
+
 template <typename match_iterator_t>
 std::vector<EdgeSegment>
-ConstructRoute(baldr::GraphReader& graphreader,
-               const MapMatcher& mapmatcher,
+ConstructRoute(const MapMatching& mapmaching,
                match_iterator_t begin,
                match_iterator_t end);
 


### PR DESCRIPTION
- [x] Remove `graphtype()` from match result. See #40 
- [x] Improve measurement interpolation. Previously measurements were interpolated into projected point on the closest edge or the closest node, which is not always best. This PR will interpolate them into the projected point where transition cost + emission cost is minimal.
- [x] Fix minor interpolation issues (see screenshots below)

Before (3, 4, 5 not interpolated):
![image](https://cloud.githubusercontent.com/assets/87357/18367799/1d60044e-761d-11e6-9e6f-ec10a56bfd16.png)

After (3, 4, 5 interpolated):
![image](https://cloud.githubusercontent.com/assets/87357/18367819/32056b3c-761d-11e6-89a7-23fdc836448e.png)


Before (2 interpolated incorrectly):
![image](https://cloud.githubusercontent.com/assets/87357/18367933/af80bf9e-761d-11e6-9220-c2c0061498cc.png)


After (2 interpolated correctly):
![image](https://cloud.githubusercontent.com/assets/87357/18367958/c9878cc4-761d-11e6-998f-005d64141178.png)
