### PR TITLE
Add optional interrupt

### DIFF
--- a/src/meili/map_matcher.cc
+++ b/src/meili/map_matcher.cc
@@ -335,7 +335,8 @@ MapMatcher::MapMatcher(const boost::property_tree::ptree& config,
       candidatequery_(candidatequery),
       mode_costing_(mode_costing),
       travelmode_(travelmode),
-      mapmatching_(graphreader_, mode_costing_, travelmode_, config_) {}
+      mapmatching_(graphreader_, mode_costing_, travelmode_, config_),
+      interrupt_(nullptr) {}
 
 
 MapMatcher::~MapMatcher() {}
@@ -345,6 +346,7 @@ std::vector<MatchResult>
 MapMatcher::OfflineMatch(const std::vector<Measurement>& measurements)
 {
   mapmatching_.Clear();
+  candidatequery_.set_interrupt(interrupt_);
 
   const auto begin = measurements.begin(),
                end = measurements.end();
@@ -399,6 +401,10 @@ MapMatcher::OfflineMatch(const std::vector<Measurement>& measurements)
 Time
 MapMatcher::AppendMeasurement(const Measurement& measurement)
 {
+  // Test interrupt
+  if (interrupt_) {
+    (*interrupt_)();
+  }
   const auto& candidates = candidatequery_.Query(
       measurement.lnglat(),
       measurement.sq_search_radius(),

--- a/valhalla/meili/candidate_search.h
+++ b/valhalla/meili/candidate_search.h
@@ -39,6 +39,14 @@ class CandidateQuery
   virtual std::vector<std::vector<baldr::PathLocation>>
   QueryBulk(const std::vector<midgard::PointLL>& points, float radius, sif::EdgeFilter filter = nullptr);
 
+  /**
+   * Set a callback that will throw when the map-matching should be aborted
+   * @param interrupt_callback  the function to periodically call to see if we should abort
+   */
+  void set_interrupt(const std::function<void ()>* interrupt_callback) {
+    interrupt_ = interrupt_callback;
+  }
+
  protected:
   template <typename edgeid_iterator_t> std::vector<baldr::PathLocation>
   WithinSquaredDistance(const midgard::PointLL& location,
@@ -48,6 +56,9 @@ class CandidateQuery
                         sif::EdgeFilter filter) const;
 
   baldr::GraphReader& reader_;
+
+  // Interrupt callback. Can be set to interrupt if connection is closed.
+  const std::function<void ()>* interrupt_;
 };
 
 
@@ -62,6 +73,14 @@ class CandidateGridQuery final: public CandidateQuery
 
   std::vector<baldr::PathLocation>
   Query(const midgard::PointLL& location, float sq_search_radius, sif::EdgeFilter filter) const override;
+
+  /**
+   * Set a callback that will throw when the map-matching should be aborted
+   * @param interrupt_callback  the function to periodically call to see if we should abort
+   */
+  void set_interrupt(const std::function<void ()>* interrupt_callback) {
+    interrupt_ = interrupt_callback;
+  }
 
   std::unordered_map<baldr::GraphId, grid_t>::size_type
   size() const

--- a/valhalla/meili/map_matcher.h
+++ b/valhalla/meili/map_matcher.h
@@ -47,6 +47,14 @@ public:
   std::vector<MatchResult>
   OfflineMatch(const std::vector<Measurement>& measurements);
 
+  /**
+   * Set a callback that will throw when the map-matching should be aborted
+   * @param interrupt_callback  the function to periodically call to see if we should abort
+   */
+  void set_interrupt(const std::function<void ()>* interrupt_callback) {
+    interrupt_ = interrupt_callback;
+  }
+
 private:
   Time AppendMeasurement(const Measurement& measurement);
 
@@ -61,6 +69,9 @@ private:
   sif::TravelMode travelmode_;
 
   MapMatching mapmatching_;
+
+  // Interrupt callback. Can be set to interrupt if connection is closed.
+  const std::function<void ()>* interrupt_;
 };
 
 }


### PR DESCRIPTION
Ad ability to interrupt AppendMeasurement and IndexTiles. An interrupt can be detected when the http connection is closed. This will throw an exception and cleanup in the calling worker. Later we may want to allow interrupt in other time intensive parts of map-matching.

For now this is only activated when going through the thor service to do map-matching. The interrupt method is set to nullptr by default.

@kevinkreiser @ptpt 