### PR TITLE
Fix the wrong distance for emission cost calculation

### DIFF
--- a/src/meili/map_matching.cc
+++ b/src/meili/map_matching.cc
@@ -204,7 +204,7 @@ MapMatching::TransitionCost(const State& left, const State& right) const
 
 inline float
 MapMatching::EmissionCost(const State& state) const
-{ return CalculateEmissionCost(std::sqrt(state.candidate().edges.front().score)); }
+{ return CalculateEmissionCost(state.candidate().edges.front().score); }
 
 
 inline double

--- a/valhalla/meili/map_matching.h
+++ b/valhalla/meili/map_matching.h
@@ -129,6 +129,8 @@ class MapMatching: public ViterbiSearch<State>
     return time;
   }
 
+  // given the *squared* great circle distance between a measurement and its candidate,
+  // return the emission cost of the candidate
   float
   CalculateEmissionCost(float sq_distance) const
   { return sq_distance * inv_double_sq_sigma_z_; }


### PR DESCRIPTION
Since `CalculateEmissionCost` takes squared distance, we don't need to square root the distance before passing in the score (which is already squared distance).

Without this fix, the emission cost is insignificant which doesn't impact candidate choice at all. If you increase search radius to 500 meters, you will see it always looks for the optimal transition cost, despite how far the candidate is:

<img width="796" alt="2017-01-22 6 25 50" src="https://cloud.githubusercontent.com/assets/87357/22184350/3c6dee78-e0d0-11e6-9d29-44c6452dfe89.png">

Had this fix applied, you see the distance plays its role!
<img width="836" alt="2017-01-22 6 23 43" src="https://cloud.githubusercontent.com/assets/87357/22184338/0fc56554-e0d0-11e6-936e-1ca225981e0d.png">
